### PR TITLE
New output formats for the log command

### DIFF
--- a/src/org/syncany/cli/CommandLineClient.java
+++ b/src/org/syncany/cli/CommandLineClient.java
@@ -398,10 +398,14 @@ public class CommandLineClient extends Client {
 		out.println("      -D, --date=<dd-mm-yy>            Restore versions prior to the given absolute date");
 		out.println("      -v, --version=<[-]version>       Restore <version> or go back <version> versions");
 		out.println();
-		out.println("  log [<paths>]");
+		out.println("  log [<args>] [<paths>]");
 		out.println("      Print to STDOUT information stored in the local database about the given file paths or");
 		out.println("      all paths known by the database if no path is given. The output format is unstable and");
 		out.println("      might change in future releases.");
+		out.println();
+		out.println("      Arguments:");
+		out.println("      -f, --format=<format>       Specifies the format to use for printing the log.");
+		out.println("      Currently recognized formats: " + LogCommand.formats);
 		out.println();
 		
 		out.close();		

--- a/src/org/syncany/cli/LogCommand.java
+++ b/src/org/syncany/cli/LogCommand.java
@@ -17,23 +17,40 @@
  */
 package org.syncany.cli;
 
+import static java.util.Arrays.asList;
+
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
+import joptsimple.OptionSpec;
 
 import org.syncany.database.FileVersion;
 import org.syncany.database.PartialFileHistory;
+import org.syncany.operations.LogOperation;
 import org.syncany.operations.LogOperation.LogOperationOptions;
 import org.syncany.operations.LogOperation.LogOperationResult;
 import org.syncany.util.StringUtil;
 
 public class LogCommand extends Command {
 	private static final DateFormat dateFormat = new SimpleDateFormat("dd-MM-yy HH:mm:ss"); 
-	
+	private static final Logger logger = Logger.getLogger(LogOperation.class.getSimpleName());
+	public static final Set<String> formats;
+	static {
+		Set<String> localFormats = new HashSet<String>();
+		localFormats.add("full");
+		localFormats.add("last");
+		formats = Collections.unmodifiableSet(localFormats);
+	}
 	@Override
 	public boolean initializedLocalDirRequired() {	
 		return true;
@@ -52,44 +69,66 @@ public class LogCommand extends Command {
 	public LogOperationOptions parseOptions(String[] operationArgs) throws Exception {
 		LogOperationOptions operationOptions = new LogOperationOptions();
 
-		OptionParser parser = new OptionParser();	
-		
-		OptionSet options = parser.parse(operationArgs);	
+		OptionParser parser = new OptionParser();
+		OptionSpec<String> optionFormat = parser.acceptsAll(asList("f", "format")).withRequiredArg().defaultsTo("full");
 
+		OptionSet options = parser.parse(operationArgs);
+
+		String format = options.valueOf(optionFormat);
+		if (!formats.contains(format)) {
+			throw new Exception("Unrecognized log format " + format);
+		}
 		// Files
 		List<?> nonOptionArgs = options.nonOptionArguments();
 		List<String> restoreFilePaths = new ArrayList<String>();
-		
+
 		for (Object nonOptionArg : nonOptionArgs) {
 			restoreFilePaths.add(nonOptionArg.toString());
 		}
 
-		operationOptions.setPaths(restoreFilePaths);	
-		
+		operationOptions.setPaths(restoreFilePaths);
+		operationOptions.setFormat(format);
+
 		return operationOptions;
+	}
+	
+	private void printOneVersion(FileVersion fileVersion) {
+		String posixPermissions = (fileVersion.getPosixPermissions() != null) ? fileVersion.getPosixPermissions() : "";
+		String dosAttributes = (fileVersion.getDosAttributes() != null) ? fileVersion.getDosAttributes() : "";
+
+		out.printf("%4d %-20s %9s %4s %8d %7s %8s %40s", fileVersion.getVersion(), dateFormat.format(fileVersion.getLastModified()),
+				posixPermissions, dosAttributes, fileVersion.getSize(), fileVersion.getType(), fileVersion.getStatus(),
+				StringUtil.toHex(fileVersion.getChecksum()));
 	}
 	
 	private void printResults(LogOperationResult operationResult) {
 		for (PartialFileHistory fileHistory : operationResult.getFileHistories()) {
-			for (FileVersion fileVersion : fileHistory.getFileVersions().values()) {
-				String posixPermissions = (fileVersion.getPosixPermissions() != null) ? fileVersion.getPosixPermissions() : "";
-				String dosAttributes = (fileVersion.getDosAttributes() != null) ? fileVersion.getDosAttributes() : "";
-				
-				out.printf(
-					"%20d %4d %-20s %9s %4s %8d %7s %8s %40s %s\n",
-					
-					fileHistory.getFileId(),
-					fileVersion.getVersion(),
-					dateFormat.format(fileVersion.getLastModified()),
-					posixPermissions,
-					dosAttributes,
-					fileVersion.getSize(),
-					fileVersion.getType(),
-					fileVersion.getStatus(),
-					StringUtil.toHex(fileVersion.getChecksum()),
-					fileVersion.getPath()				
-				);
+			FileVersion lastVersion = fileHistory.getLastVersion();
+			out.printf("%s %16x", lastVersion.getPath(), fileHistory.getFileId());
+			switch (operationResult.getFormat()) {
+			case "full":
+				Iterator<Long> fileVersionNumber = fileHistory.getDescendingVersionNumber();
+				out.println();
+				while (fileVersionNumber.hasNext()) {
+					FileVersion fileVersion = fileHistory.getFileVersion(fileVersionNumber.next());
+					out.print('\t');
+					printOneVersion(fileVersion);
+					if (fileVersion.getPath().equals(lastVersion.getPath())) {
+						out.println();
+					} else {
+						out.println(" " + fileVersion.getPath());
+					}
+				}
+				break;
+			case "last":
+				out.print(' ');
+				printOneVersion(lastVersion);
+				out.println();
+				break;
+			default:
+				out.println(" unkown format " + operationResult.getFormat());
+				logger.log(Level.SEVERE, "Unrecognized lof format, should have been rejected earlier " + operationResult.getFormat());
 			}
 		}
-	}	
+	}
 }

--- a/src/org/syncany/database/PartialFileHistory.java
+++ b/src/org/syncany/database/PartialFileHistory.java
@@ -18,6 +18,7 @@
 package org.syncany.database;
 
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Random;
 import java.util.TreeMap;
@@ -63,6 +64,15 @@ public class PartialFileHistory {
         return versions.lastEntry().getValue();
     }   
 
+    /**
+     * Returns an iterator on the version numbers stored in this partial history, in reverse order. 
+     * 
+     * @return an iterator on the version numbers in reverse order 
+     */
+    public Iterator<Long> getDescendingVersionNumber() {
+    	return Collections.unmodifiableSet(versions.descendingKeySet()).iterator();
+    }
+    
     /* package */ void addFileVersion(FileVersion fileVersion) {
         versions.put(fileVersion.getVersion(), fileVersion);        
     }

--- a/src/org/syncany/operations/LogOperation.java
+++ b/src/org/syncany/operations/LogOperation.java
@@ -66,7 +66,7 @@ public class LogOperation extends Operation {
 			fileHistories = getFileHistoriesByPath(options.getPaths(), database);
 		}
 		
-		return new LogOperationResult(fileHistories);
+		return new LogOperationResult(fileHistories,options.getFormat());
 	}			
 	
 	private List<PartialFileHistory> getFileHistoriesByPath(List<String> filePaths, Database database) {				
@@ -89,6 +89,8 @@ public class LogOperation extends Operation {
 	public static class LogOperationOptions implements OperationOptions {
 		private List<String> paths;		
 		
+		private String format;
+		
 		public List<String> getPaths() {
 			return paths;
 		}
@@ -96,17 +98,35 @@ public class LogOperation extends Operation {
 		public void setPaths(List<String> paths) {
 			this.paths = paths;
 		}
+
+		public String getFormat() {
+			return format;
+		}
+
+		public void setFormat(String format) {
+			this.format = format;
+		}
+		
+		
 	}
 	
 	public class LogOperationResult implements OperationResult {
 		private List<PartialFileHistory> fileHistories;
 		
-		public LogOperationResult(List<PartialFileHistory> fileHistories) {
+		private String format;
+		
+		public LogOperationResult(List<PartialFileHistory> fileHistories, String format) {
 			this.fileHistories = fileHistories;
+			this.format =format;
 		}
 
 		public List<PartialFileHistory> getFileHistories() {
 			return fileHistories;
-		}				
+		}	
+		
+		public String getFormat() {
+			return format;
+		}
+		
 	}
 }

--- a/tests/org/syncany/tests/cli/LogCommandTest.java
+++ b/tests/org/syncany/tests/cli/LogCommandTest.java
@@ -60,7 +60,7 @@ public class LogCommandTest {
 			"log"
 		}));
 		
-		assertEquals("Different number of output lines expected.", 4, cliOut.length);
+		assertEquals("Different number of output lines expected.", 7, cliOut.length);
 		// TODO [low] How to test the log command any further? Non-deterministic output!
 		
 		TestCliUtil.deleteTestLocalConfigAndData(clientA);		


### PR DESCRIPTION
Hi Philipp, 

As promised, some modifications of the log command output. There are now two output formats (full and last). 

In the "last" format, one line is printed for each file, the last version known by the database. The display is close to the one you used with two differences: the current path is used at the beginning of the line and the file Id is printed in hexadecimal. 

The "full" format is similar to the original log display with the above modifications. In addition, it prints (as the name says) all the versions in reverse order. Moreover, it displays as a "title" the current path of the file and its id. On the junit test, this gives:
file1 b3bd89d064113fbe
       2 19-11-13 13:48:48    rw-rw-r--         20480    FILE  CHANGED 31ee116172cba1aee6aad0481d277617ea10ed4a
       1 19-11-13 13:48:48    rw-rw-r--         20480    FILE      NEW 18af5de85e119d23f47cdd30189a3f541a899561
file3 890d8a5a57b42077
       1 19-11-13 13:48:48    rw-rw-r--         20480    FILE      NEW 6857f6fde61dc8dab1914e7b99481240947c4879
file2 25a1a0f66269d61a
       1 19-11-13 13:48:48    rw-rw-r--         20480    FILE      NEW 2512bae3417cde59c3134f8a59e26cc81d102ea7

The implementation is straightforward but a bit convolved, I'll send later an email about my thoughts on the CLI internal design.

Best regards,

Fabrice
