### PR TITLE
Closing resources

### DIFF
--- a/syncany-lib/src/main/java/org/syncany/database/dao/ApplicationSqlDao.java
+++ b/syncany-lib/src/main/java/org/syncany/database/dao/ApplicationSqlDao.java
@@ -48,20 +48,20 @@ public class ApplicationSqlDao extends AbstractSqlDao {
 		
 		preparedStatement.executeBatch();
 		connection.commit();
+		preparedStatement.close();
 	}
 	
 	public List<String> getKnownDatabases() {
 		List<String> knownDatabases = new ArrayList<String>();
 		
-		try {
-			PreparedStatement preparedStatement = getStatement("/sql/select.getKnownDatabases.sql");					
-			ResultSet resultSet = preparedStatement.executeQuery();
-
-			while (resultSet.next()) {
-				knownDatabases.add(resultSet.getString("database_name"));
+		
+		try (PreparedStatement preparedStatement = getStatement("/sql/select.getKnownDatabases.sql")) {
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {		
+				while (resultSet.next()) {
+					knownDatabases.add(resultSet.getString("database_name"));
+				}
+				return knownDatabases;
 			}
-
-			return knownDatabases;
 		}
 		catch (SQLException e) {
 			throw new RuntimeException(e);

--- a/syncany-lib/src/main/java/org/syncany/database/dao/ChunkSqlDao.java
+++ b/syncany-lib/src/main/java/org/syncany/database/dao/ChunkSqlDao.java
@@ -56,6 +56,7 @@ public class ChunkSqlDao extends AbstractSqlDao {
 			}
 			
 			preparedStatement.executeBatch();
+			preparedStatement.close();
 		}
 	}
 	
@@ -68,11 +69,10 @@ public class ChunkSqlDao extends AbstractSqlDao {
 	}
 	
 	private void loadChunkCache() {
-		try {
-			PreparedStatement preparedStatement = getStatement("/sql/select.loadChunkCache.sql");
-			ResultSet resultSet = preparedStatement.executeQuery();
-
-			chunkCache = createChunkEntries(resultSet);
+		try (PreparedStatement preparedStatement = getStatement("/sql/select.loadChunkCache.sql")){
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				chunkCache = createChunkEntries(resultSet);
+			}
 		}
 		catch (SQLException e) {
 			throw new RuntimeException(e);
@@ -80,19 +80,19 @@ public class ChunkSqlDao extends AbstractSqlDao {
 	}
 	
 	public Map<ChunkChecksum, ChunkEntry> getChunksForDatabaseVersion(VectorClock vectorClock) {
-		try {
-			PreparedStatement preparedStatement = getStatement("/sql/select.getChunksForDatabaseVersion.sql");			
+		try (PreparedStatement preparedStatement = getStatement("/sql/select.getChunksForDatabaseVersion.sql")){
 			
 			preparedStatement.setString(1, vectorClock.toString());
 			preparedStatement.setString(2, vectorClock.toString());
 
-			ResultSet resultSet = preparedStatement.executeQuery();
-			return createChunkEntries(resultSet);
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				return createChunkEntries(resultSet);
+			}
 		}
 		catch (SQLException e) {
 			throw new RuntimeException(e);
 		}
-	}	
+	}
 	
 	protected Map<ChunkChecksum, ChunkEntry> createChunkEntries(ResultSet resultSet) throws SQLException {
 		Map<ChunkChecksum, ChunkEntry> chunks = new HashMap<ChunkChecksum, ChunkEntry>();

--- a/syncany-lib/src/main/java/org/syncany/database/dao/FileVersionSqlDao.java
+++ b/syncany-lib/src/main/java/org/syncany/database/dao/FileVersionSqlDao.java
@@ -76,11 +76,11 @@ public class FileVersionSqlDao extends AbstractSqlDao {
 		}				
 		
 		preparedStatement.executeBatch();
+		preparedStatement.close();
 	}
 	
 	public Map<String, FileVersion> getCurrentFileTree() {		
-		try {
-			PreparedStatement preparedStatement = getStatement("/sql/fileversion.select.master.getCurrentFileTree.sql");		
+		try (PreparedStatement preparedStatement = getStatement("/sql/fileversion.select.master.getCurrentFileTree.sql")) {
 			return getFileTree(preparedStatement);				
 		}
 		catch (SQLException e) {
@@ -89,9 +89,7 @@ public class FileVersionSqlDao extends AbstractSqlDao {
 	}
 	
 	public Map<String, FileVersion> getFileTreeAtDate(Date date) {		
-		try {
-			PreparedStatement preparedStatement = getStatement("/sql/fileversion.select.master.getFileTreeAtDate.sql");
-			
+		try (PreparedStatement preparedStatement = getStatement("/sql/fileversion.select.master.getFileTreeAtDate.sql")) {
 			preparedStatement.setTimestamp(1, new Timestamp(date.getTime()));
 			preparedStatement.setTimestamp(2, new Timestamp(date.getTime()));
 			
@@ -105,9 +103,7 @@ public class FileVersionSqlDao extends AbstractSqlDao {
 	private Map<String, FileVersion> getFileTree(PreparedStatement preparedStatement) {
 		Map<String, FileVersion> fileTree = new HashMap<String, FileVersion>();
 
-		try {
-			ResultSet resultSet = preparedStatement.executeQuery();
-
+		try (ResultSet resultSet = preparedStatement.executeQuery()) {
 			while (resultSet.next()) {
 				FileVersion fileVersion = createFileVersionFromRow(resultSet);
 				fileTree.put(fileVersion.getPath(), fileVersion);
@@ -121,14 +117,12 @@ public class FileVersionSqlDao extends AbstractSqlDao {
 	}
 	
 	public FileVersion getFileVersionByPath(String path) {
-		try {
-			PreparedStatement preparedStatement = getStatement("/sql/fileversion.select.master.getFileVersionByPath.sql");
+		try (PreparedStatement preparedStatement = getStatement("/sql/fileversion.select.master.getFileVersionByPath.sql")) {
 			preparedStatement.setString(1, path);
-
-			ResultSet resultSet = preparedStatement.executeQuery();
-
-			if (resultSet.next()) {
-				return createFileVersionFromRow(resultSet);
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				if (resultSet.next()) {
+					return createFileVersionFromRow(resultSet);
+				}
 			}
 
 			return null;
@@ -139,14 +133,13 @@ public class FileVersionSqlDao extends AbstractSqlDao {
 	}
 	
 	public FileVersion getFileVersionByFileHistoryId(FileHistoryId fileHistoryId) {
-		try {
-			PreparedStatement preparedStatement = getStatement("/sql/fileversion.select.master.getFileVersionByFileHistoryId.sql");
+		try (PreparedStatement preparedStatement = getStatement("/sql/fileversion.select.master.getFileVersionByFileHistoryId.sql")) {
 			preparedStatement.setString(1, fileHistoryId.toString());
 
-			ResultSet resultSet = preparedStatement.executeQuery();
-
-			if (resultSet.next()) {
-				return createFileVersionFromRow(resultSet);
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				if (resultSet.next()) {
+					return createFileVersionFromRow(resultSet);
+				}
 			}
 
 			return null;


### PR DESCRIPTION
I've been looking at all the sqlplayground branch and while familiarizing myself with it I noticed that PreparedStatements and ResultSets are hardly ever closed. While the javadoc suggests that those might be closed when the connection is, the internet (represented by stackoverflow: https://stackoverflow.com/questions/4507440/must-jdbc-resultsets-and-statements-be-closed-separately-although-the-connection) suggests that it is a good idea to close them just to be sure. 

I followed the following rule: If the method throws SQLException I used close() at the appropriate time, if the method was try-catching, I used try-with-resources.

My main reason for actually implementing this are the "Cannot persist Database" errors I keep getting with various tests, but this does not seem to fix that issue. (Since this is a work in progress and I saw some commit log about weirdly undeterministic failing tests, I take you are aware of this. If not, let me know and I can get some stacktraces to you.)
