### PR TITLE
Timing in a test

### DIFF
--- a/syncany-lib/src/test/java/org/syncany/tests/scenarios/FileVanishedScenarioTest.java
+++ b/syncany-lib/src/test/java/org/syncany/tests/scenarios/FileVanishedScenarioTest.java
@@ -82,6 +82,7 @@ public class FileVanishedScenarioTest {
 			@Override
 			public void run() {
 				try {
+					Thread.sleep(40);
 					clientA.up();
 				}
 				catch (Exception e) {
@@ -96,7 +97,7 @@ public class FileVanishedScenarioTest {
 		logger.log(Level.INFO, "Starting 'up' thread ...");		
 		runUpThread.start();
 		
-		Thread.sleep(200);
+		
 
 		logger.log(Level.INFO, "Starting 'delete' thread ...");
 		deleteFilesThread.start();		


### PR DESCRIPTION
I recently switched to Arch and one of the side-effects was that FileVanishedScenarioTest failed, because the deleting of files doesn't even start before the up is finished. (It failed at "There should be less file histories than originally added files.") I think these timings produce the race condition more reliably. (I think this performance increase was because /tmp is tmpfs which is in RAM, but I'm not entirely sure.) 
