### PR TITLE
autoconverting wildcards to regexps

### DIFF
--- a/syncany-lib/src/main/java/org/syncany/config/IgnoredFiles.java
+++ b/syncany-lib/src/main/java/org/syncany/config/IgnoredFiles.java
@@ -80,7 +80,7 @@ public class IgnoredFiles {
 							ignorePatterns.add(ignorePattern.substring(6));
 						}
 						else {
-							if (ignorePattern.contains("*")) {
+							if (ignorePattern.contains("*") || ignorePattern.contains("?")) {
 								// wildcards handling, converting them to regexps
 								ignorePatterns.add(wildcardsToRegexp(ignorePattern));
 							}
@@ -124,7 +124,7 @@ public class IgnoredFiles {
 					out.append(c);
 			}
 		}
-		out.append( '$' );
+		out.append('$');
 		return out.toString();
 	}
 } 

--- a/syncany-lib/src/test/java/org/syncany/tests/scenarios/IgnoredFileScenarioTest.java
+++ b/syncany-lib/src/test/java/org/syncany/tests/scenarios/IgnoredFileScenarioTest.java
@@ -158,12 +158,13 @@ public class IgnoredFileScenarioTest {
 		
 		//Create ignore file and reload it
 		File syncanyIgnore = clientA.getLocalFile(Config.FILE_IGNORE);
-		TestFileUtil.createFileWithContent(syncanyIgnore, "*.bak");
+		TestFileUtil.createFileWithContent(syncanyIgnore, "*.bak\nignoredarchive.r??");
 		clientA.getConfig().getIgnoredFiles().loadPatterns();
 		
 		// A new/up
 		clientA.createNewFile("ignoredfile.bak");	
-		clientA.createNewFile("nonignoredfile.bar");	
+		clientA.createNewFile("nonignoredfile.bar");
+		clientA.createNewFile("ignoredarchive.r01");		
 		clientA.up();
 		
 		clientB.down();
@@ -173,6 +174,8 @@ public class IgnoredFileScenarioTest {
 		assertFalse(clientB.getLocalFile("ignoredfile.bak").exists());
 		assertTrue(clientA.getLocalFile("nonignoredfile.bar").exists());
 		assertTrue(clientB.getLocalFile("nonignoredfile.bar").exists());
+		assertTrue(clientA.getLocalFile("ignoredarchive.r01").exists());
+		assertFalse(clientB.getLocalFile("ignoredarchive.r01").exists());
 		
 		// Tear down
 		clientA.deleteTestData();


### PR DESCRIPTION
[19:53] <vadimpanin> Hello Pim. Is it documented somewhere yet? I think it's defying the principle of minimum unexpectedness (if it's a real term :). I see two options: output errors to the console if user tries to use .syignore with lines that have \* in it, but do not start  with "regexp:", or convert thouse to regular expressions right away (replacing \* with .\* for example and adding $/^).
[19:54] <aureianimus> Hiya Vadim:)
[19:55] <aureianimus> you're absolutely right
[19:55] <aureianimus> (it's not documented anywhere)
[19:56] <aureianimus> the thing is that i started on this and the idea was to have an IgnoreOperation and be able to ignore files that are already versioned, but that was so big we decided it was out of scope for at least the near future, and then i whipped this up
[19:58] <aureianimus> i took a look at the gitignore spec, but that seemed way to much to implement all, if you'd like to treat wildcards seperately, that would be a good idea
