### PR TITLE
Resolves Issue #156

### DIFF
--- a/gradle/daemon/syncanyd.bat
+++ b/gradle/daemon/syncanyd.bat
@@ -119,7 +119,7 @@ if %RUNNING% == 1 (
   goto mainEnd
 ) 
 
-set CLASSPATH=%APP_HOME%\lib\*;%AppData%\Syncany\plugins\*
+set CLASSPATH=%APP_HOME%\lib\*;%AppData%\Syncany\plugins\lib\*
 
 echo | set /p=Starting daemon: .
 start "" /b "%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% -classpath "%CLASSPATH%" org.syncany.Syncany --log=%APP_LOG_FILE% daemon


### PR DESCRIPTION
When starting syncany as daemon in Windows, plugins installed with sy plugin install webdav are not recognized. The reason is, that in the plugins are stored in %AppData%\Syncany\plugins\lib* but sysd.bat sets the classpath to %AppData%\Syncany\plugins*.
