### PR TITLE
Subfolder based TransferManagers

### DIFF
--- a/syncany-lib/src/main/java/org/syncany/operations/AbstractTransferOperation.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/AbstractTransferOperation.java
@@ -91,6 +91,7 @@ public abstract class AbstractTransferOperation extends Operation {
 		TransferManager pluginTransferManager = config.getTransferPlugin().createTransferManager(config.getConnection(), config);
 
 		if (pluginTransferManager instanceof FolderizableTransferManager) {
+			logger.log(Level.INFO, "Creating FolderAwareTransferManager");
 			return new FolderAwareTransferManager((FolderizableTransferManager) pluginTransferManager);
 		}
 

--- a/syncany-lib/src/main/java/org/syncany/operations/AbstractTransferOperation.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/AbstractTransferOperation.java
@@ -25,6 +25,8 @@ import java.util.logging.Logger;
 
 import org.syncany.config.Config;
 import org.syncany.config.LocalEventBus;
+import org.syncany.plugins.transfer.FolderizableTransferManager;
+import org.syncany.plugins.transfer.FolderAwareTransferManager;
 import org.syncany.plugins.transfer.RetriableTransferManager;
 import org.syncany.plugins.transfer.StorageException;
 import org.syncany.plugins.transfer.TransactionAwareTransferManager;
@@ -82,7 +84,17 @@ public abstract class AbstractTransferOperation extends Operation {
 	}
 
 	private TransferManager createRetriableTransferManager(Config config) throws StorageException {
-		return new RetriableTransferManager(config.getTransferPlugin().createTransferManager(config.getConnection(), config));
+		return new RetriableTransferManager(createTransferManager(config));
+	}
+
+	private TransferManager createTransferManager(Config config) throws StorageException {
+		TransferManager pluginTransferManager = config.getTransferPlugin().createTransferManager(config.getConnection(), config);
+
+		if (pluginTransferManager instanceof FolderizableTransferManager) {
+			return new FolderAwareTransferManager((FolderizableTransferManager) pluginTransferManager);
+		}
+
+		return pluginTransferManager;
 	}
 
 	protected void startOperation() throws Exception {

--- a/syncany-lib/src/main/java/org/syncany/operations/AbstractTransferOperation.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/AbstractTransferOperation.java
@@ -25,7 +25,7 @@ import java.util.logging.Logger;
 
 import org.syncany.config.Config;
 import org.syncany.config.LocalEventBus;
-import org.syncany.plugins.transfer.FolderizableTransferManager;
+import org.syncany.plugins.transfer.Folderable;
 import org.syncany.plugins.transfer.FolderAwareTransferManager;
 import org.syncany.plugins.transfer.RetriableTransferManager;
 import org.syncany.plugins.transfer.StorageException;
@@ -90,9 +90,9 @@ public abstract class AbstractTransferOperation extends Operation {
 	private TransferManager createTransferManager(Config config) throws StorageException {
 		TransferManager pluginTransferManager = config.getTransferPlugin().createTransferManager(config.getConnection(), config);
 
-		if (pluginTransferManager instanceof FolderizableTransferManager) {
+		if (pluginTransferManager instanceof Folderable) {
 			logger.log(Level.INFO, "Creating FolderAwareTransferManager");
-			return new FolderAwareTransferManager((FolderizableTransferManager) pluginTransferManager);
+			return new FolderAwareTransferManager((Folderable) pluginTransferManager);
 		}
 
 		return pluginTransferManager;

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/FolderAwareTransferManager.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/FolderAwareTransferManager.java
@@ -33,9 +33,9 @@ public class FolderAwareTransferManager implements TransferManager {
 	private static final Logger logger = Logger.getLogger(FolderAwareTransferManager.class.getSimpleName());
 	private static final char FOLDER_SEPERATOR = '/';
 
-	private final FolderizableTransferManager underlyingTransferManager;
+	private final Folderable underlyingTransferManager;
 
-	public FolderAwareTransferManager(FolderizableTransferManager underlyingTransferManager) {
+	public FolderAwareTransferManager(Folderable underlyingTransferManager) {
 		this.underlyingTransferManager = underlyingTransferManager;
 	}
 

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/FolderAwareTransferManager.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/FolderAwareTransferManager.java
@@ -125,7 +125,7 @@ public class FolderAwareTransferManager implements TransferManager {
 		}
 
 		// we need to use the hash value of a file's name because some files aren't folderizable by default
-		String fileId = StringUtil.toHex(DigestUtils.sha256(remoteFile.getName()));
+		String fileId = StringUtil.toHex(DigestUtils.sha256(remoteFile.getSimpleName()));
 		StringBuilder path = new StringBuilder();
 
 		for (int i = 0; i < underlyingTransferManager.getSubfolderDepth(); i++) {
@@ -133,7 +133,7 @@ public class FolderAwareTransferManager implements TransferManager {
 			path.append(FOLDER_SEPERATOR);
 		}
 
-		return RemoteFile.createRemoteFileWithPath(path.toString(), remoteFile.getName(), remoteFile.getClass());
+		return RemoteFile.createRemoteFileWithPath(remoteFile.getSimpleName(), path.toString(), remoteFile.getClass());
 	}
 
 }

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/FolderAwareTransferManager.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/FolderAwareTransferManager.java
@@ -1,0 +1,138 @@
+/*
+ * Syncany, www.syncany.org
+ * Copyright (C) 2011-2015 Philipp C. Heckel <philipp.heckel@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.syncany.plugins.transfer;
+
+import java.io.File;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.syncany.plugins.transfer.files.RemoteFile;
+import org.syncany.util.StringUtil;
+
+/**
+ * @author Christian Roth <christian.roth@port17.de>
+ */
+
+public class FolderAwareTransferManager implements TransferManager {
+	private static final Logger logger = Logger.getLogger(FolderAwareTransferManager.class.getSimpleName());
+
+	private final FolderizableTransferManager underlyingTransferManager;
+
+	public FolderAwareTransferManager(FolderizableTransferManager underlyingTransferManager) {
+		this.underlyingTransferManager = underlyingTransferManager;
+	}
+
+	@Override
+	public void connect() throws StorageException {
+		underlyingTransferManager.connect();
+	}
+
+	@Override
+	public void disconnect() throws StorageException {
+		underlyingTransferManager.disconnect();
+	}
+
+	@Override
+	public void init(final boolean createIfRequired) throws StorageException {
+		underlyingTransferManager.init(createIfRequired);
+	}
+
+	@Override
+	public void download(final RemoteFile remoteFile, final File localFile) throws StorageException {
+		underlyingTransferManager.download(createPathAwareRemoteFile(remoteFile), localFile);
+	}
+
+	@Override
+	public void move(final RemoteFile sourceFile, final RemoteFile targetFile) throws StorageException {
+		final RemoteFile pathAwareTargetFile = createPathAwareRemoteFile(targetFile);
+		underlyingTransferManager.createPathIfRequired(pathAwareTargetFile);
+		underlyingTransferManager.move(createPathAwareRemoteFile(sourceFile), pathAwareTargetFile);
+	}
+
+	@Override
+	public void upload(final File localFile, final RemoteFile remoteFile) throws StorageException {
+		final RemoteFile pathAwareRemoteFile = createPathAwareRemoteFile(remoteFile);
+		underlyingTransferManager.createPathIfRequired(pathAwareRemoteFile);
+		underlyingTransferManager.upload(localFile, pathAwareRemoteFile);
+	}
+
+	@Override
+	public boolean delete(final RemoteFile remoteFile) throws StorageException {
+		return underlyingTransferManager.delete(createPathAwareRemoteFile(remoteFile));
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T extends RemoteFile> Map<String, T> list(final Class<T> remoteFileClass) throws StorageException {
+		return underlyingTransferManager.list(remoteFileClass);
+	}
+
+	@Override
+	public StorageTestResult test(boolean testCreateTarget) {
+		return underlyingTransferManager.test(testCreateTarget);
+	}
+
+	@Override
+	public boolean testTargetExists() throws StorageException {
+		return underlyingTransferManager.testTargetExists();
+	}
+
+	@Override
+	public boolean testTargetCanWrite() throws StorageException {
+		return underlyingTransferManager.testTargetCanWrite();
+	}
+
+	@Override
+	public boolean testTargetCanCreate() throws StorageException {
+		return underlyingTransferManager.testTargetCanCreate();
+	}
+
+	@Override
+	public boolean testRepoFileExists() throws StorageException {
+		return underlyingTransferManager.testRepoFileExists();
+	}
+
+	private boolean isFolderizable(Class<? extends RemoteFile> remoteFileClass) {
+		for (Class<? extends RemoteFile> remoteFileClassEl : underlyingTransferManager.getFolderizableFiles()) {
+			if (remoteFileClass.equals(remoteFileClassEl)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private RemoteFile createPathAwareRemoteFile(RemoteFile remoteFile) throws StorageException {
+		if (!isFolderizable(remoteFile.getClass())) {
+			return remoteFile;
+		}
+
+		// we need to use the hash value of a file's name because some files aren't folderizable by default
+		String fileId = StringUtil.toHex(DigestUtils.sha256(remoteFile.getName()));
+		StringBuilder sb = new StringBuilder();
+
+		for (int i = 0; i < underlyingTransferManager.getSubfolderDepth(); i++) {
+			sb.append(fileId.substring(i * underlyingTransferManager.getBytesPerFolder(), (i + 1) * underlyingTransferManager.getBytesPerFolder()));
+			sb.append("/");
+		}
+
+		return RemoteFile.createRemoteFile(sb.toString(), remoteFile.getClass());
+	}
+
+}

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/FolderAwareTransferManager.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/FolderAwareTransferManager.java
@@ -31,6 +31,7 @@ import org.syncany.util.StringUtil;
 
 public class FolderAwareTransferManager implements TransferManager {
 	private static final Logger logger = Logger.getLogger(FolderAwareTransferManager.class.getSimpleName());
+	private static final char FOLDER_SEPERATOR = '/';
 
 	private final FolderizableTransferManager underlyingTransferManager;
 
@@ -129,10 +130,10 @@ public class FolderAwareTransferManager implements TransferManager {
 
 		for (int i = 0; i < underlyingTransferManager.getSubfolderDepth(); i++) {
 			sb.append(fileId.substring(i * underlyingTransferManager.getBytesPerFolder(), (i + 1) * underlyingTransferManager.getBytesPerFolder()));
-			sb.append("/");
+			sb.append(FOLDER_SEPERATOR);
 		}
 
-		return RemoteFile.createRemoteFile(sb.toString(), remoteFile.getClass());
+		return RemoteFile.createRemoteFileWithPath(sb.toString(), remoteFile.getName(), remoteFile.getClass());
 	}
 
 }

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/FolderAwareTransferManager.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/FolderAwareTransferManager.java
@@ -62,14 +62,22 @@ public class FolderAwareTransferManager implements TransferManager {
 	@Override
 	public void move(final RemoteFile sourceFile, final RemoteFile targetFile) throws StorageException {
 		final RemoteFile pathAwareTargetFile = createPathAwareRemoteFile(targetFile);
-		underlyingTransferManager.createPathIfRequired(pathAwareTargetFile);
+
+		if (!underlyingTransferManager.createPathIfRequired(pathAwareTargetFile)) {
+			throw new StorageException("Unable to create path for " + pathAwareTargetFile);
+		}
+
 		underlyingTransferManager.move(createPathAwareRemoteFile(sourceFile), pathAwareTargetFile);
 	}
 
 	@Override
 	public void upload(final File localFile, final RemoteFile remoteFile) throws StorageException {
 		final RemoteFile pathAwareRemoteFile = createPathAwareRemoteFile(remoteFile);
-		underlyingTransferManager.createPathIfRequired(pathAwareRemoteFile);
+
+		if (!underlyingTransferManager.createPathIfRequired(pathAwareRemoteFile)) {
+			throw new StorageException("Unable to create path for " + pathAwareRemoteFile);
+		}
+
 		underlyingTransferManager.upload(localFile, pathAwareRemoteFile);
 	}
 
@@ -110,13 +118,7 @@ public class FolderAwareTransferManager implements TransferManager {
 	}
 
 	private boolean isFolderizable(Class<? extends RemoteFile> remoteFileClass) {
-		for (Class<? extends RemoteFile> remoteFileClassEl : underlyingTransferManager.getFolderizableFiles()) {
-			if (remoteFileClass.equals(remoteFileClassEl)) {
-				return true;
-			}
-		}
-
-		return false;
+		return underlyingTransferManager.getFolderizableFiles().contains(remoteFileClass);
 	}
 
 	private RemoteFile createPathAwareRemoteFile(RemoteFile remoteFile) throws StorageException {

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/FolderAwareTransferManager.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/FolderAwareTransferManager.java
@@ -126,14 +126,14 @@ public class FolderAwareTransferManager implements TransferManager {
 
 		// we need to use the hash value of a file's name because some files aren't folderizable by default
 		String fileId = StringUtil.toHex(DigestUtils.sha256(remoteFile.getName()));
-		StringBuilder sb = new StringBuilder();
+		StringBuilder path = new StringBuilder();
 
 		for (int i = 0; i < underlyingTransferManager.getSubfolderDepth(); i++) {
-			sb.append(fileId.substring(i * underlyingTransferManager.getBytesPerFolder(), (i + 1) * underlyingTransferManager.getBytesPerFolder()));
-			sb.append(FOLDER_SEPERATOR);
+			path.append(fileId.substring(i * underlyingTransferManager.getBytesPerFolder(), (i + 1) * underlyingTransferManager.getBytesPerFolder()));
+			path.append(FOLDER_SEPERATOR);
 		}
 
-		return RemoteFile.createRemoteFileWithPath(sb.toString(), remoteFile.getName(), remoteFile.getClass());
+		return RemoteFile.createRemoteFileWithPath(path.toString(), remoteFile.getName(), remoteFile.getClass());
 	}
 
 }

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/Folderable.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/Folderable.java
@@ -28,7 +28,7 @@ import com.google.common.collect.ImmutableList;
  * @author Christian Roth <christian.roth@port17.de>
  */
 
-public interface FolderizableTransferManager extends TransferManager {
+public interface Folderable extends TransferManager {
 
 	public static final int BYTES_PER_FOLDER = 2;
 	public static final int SUBFOLDER_DEPTH = 2;

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/FolderizableTransferManager.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/FolderizableTransferManager.java
@@ -41,4 +41,5 @@ public interface FolderizableTransferManager extends TransferManager {
 	public List<Class<? extends RemoteFile>> getFolderizableFiles();
 
 	public boolean createPathIfRequired(RemoteFile remoteFile);
+
 }

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/FolderizableTransferManager.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/FolderizableTransferManager.java
@@ -1,0 +1,44 @@
+/*
+ * Syncany, www.syncany.org
+ * Copyright (C) 2011-2015 Philipp C. Heckel <philipp.heckel@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.syncany.plugins.transfer;
+
+import java.util.List;
+
+import org.syncany.plugins.transfer.files.MultichunkRemoteFile;
+import org.syncany.plugins.transfer.files.RemoteFile;
+import org.syncany.plugins.transfer.files.TempRemoteFile;
+import com.google.common.collect.ImmutableList;
+
+/**
+ * @author Christian Roth <christian.roth@port17.de>
+ */
+
+public interface FolderizableTransferManager extends TransferManager {
+
+	public static final int BYTES_PER_FOLDER = 2;
+	public static final int SUBFOLDER_DEPTH = 2;
+	public static final List<Class<? extends RemoteFile>> FOLDERIZABLE_FILES = ImmutableList.<Class<? extends RemoteFile>>builder().add(MultichunkRemoteFile.class).add(TempRemoteFile.class).build();
+
+	public int getBytesPerFolder();
+
+	public int getSubfolderDepth();
+
+	public List<Class<? extends RemoteFile>> getFolderizableFiles();
+
+	public boolean createPathIfRequired(RemoteFile remoteFile);
+}

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/files/ActionRemoteFile.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/files/ActionRemoteFile.java
@@ -1,6 +1,6 @@
 /*
  * Syncany, www.syncany.org
- * Copyright (C) 2011-2015 Philipp C. Heckel <philipp.heckel@gmail.com> 
+ * Copyright (C) 2011-2015 Philipp C. Heckel <philipp.heckel@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,14 +24,14 @@ import org.syncany.plugins.transfer.StorageException;
 
 /**
  * Action remote files represent a running transfer operation on the remote storage. Transfer
- * operations are operations that modify the repository and/or are relevant for the 
+ * operations are operations that modify the repository and/or are relevant for the
  * consistency of the local directory or the remote repository. Action files have no content,
  * they are just markers and exist only while an operation is running.
- * 
+ *
  * <p><b>Name pattern:</b> The name pattern of an action file is
- * <b>action-&lt;operationname&gt;-&lt;machinename&gt;-&lt;timestamp&gt;</b>. Initializing an 
+ * <b>action-&lt;operationname&gt;-&lt;machinename&gt;-&lt;timestamp&gt;</b>. Initializing an
  * instance with a non-matching name will throw an exception.
- * 
+ *
  * @author Philipp C. Heckel <philipp.heckel@gmail.com>
  */
 public class ActionRemoteFile extends RemoteFile {
@@ -46,8 +46,16 @@ public class ActionRemoteFile extends RemoteFile {
 		super(name);
 	}
 
+	public ActionRemoteFile(String name, String path) throws StorageException {
+		super(name, path);
+	}
+
 	public ActionRemoteFile(String operationName, String clientName, long timestamp) throws StorageException {
 		super(String.format(NAME_FORMAT, operationName, clientName, timestamp));
+	}
+
+	public ActionRemoteFile(String operationName, String clientName, long timestamp, String path) throws StorageException {
+		super(String.format(NAME_FORMAT, operationName, clientName, timestamp), path);
 	}
 
 	public String getOperationName() {
@@ -61,7 +69,7 @@ public class ActionRemoteFile extends RemoteFile {
 	public long getTimestamp() {
 		return timestamp;
 	}
-	
+
 	@Override
 	protected String validateName(String name) throws StorageException {
 		Matcher matcher = NAME_PATTERN.matcher(name);

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/files/CleanupRemoteFile.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/files/CleanupRemoteFile.java
@@ -1,6 +1,6 @@
 /*
  * Syncany, www.syncany.org
- * Copyright (C) 2011-2015 Philipp C. Heckel <philipp.heckel@gmail.com> 
+ * Copyright (C) 2011-2015 Philipp C. Heckel <philipp.heckel@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,10 +24,10 @@ import org.syncany.plugins.transfer.StorageException;
 
 /**
  * The transaction file only exists as an indicator to other clients a cleanup has occurred.
- * 
+ *
  * <p><b>Name pattern:</b> The name pattern of a cleanup file is
  * <b>cleanup-&lt;cleanupnumber&gt;</b>.
- * 
+ *
  * @author Pim Otte
  */
 public class CleanupRemoteFile extends RemoteFile {
@@ -37,23 +37,31 @@ public class CleanupRemoteFile extends RemoteFile {
 	private long cleanupNumber;
 
 	/**
-	 * Initializes a new cleanup file, given a name. 
-	 * 
-	 * @param name cleanup file name; <b>must</b> always match the {@link #NAME_PATTERN} 
+	 * Initializes a new cleanup file, given a name.
+	 *
+	 * @param name cleanup file name; <b>must</b> always match the {@link #NAME_PATTERN}
 	 * @throws StorageException If the name is not match the name pattern
 	 */
 	public CleanupRemoteFile(String name) throws StorageException {
 		super(name);
 	}
 
+	public CleanupRemoteFile(String name, String path) throws StorageException {
+		super(name, path);
+	}
+
 	/**
-	 * Initializes a new transaction file, given which cleanup has occurred 
-	 * 
+	 * Initializes a new transaction file, given which cleanup has occurred
+	 *
 	 * @param remoteTransaction the remoteTransaction for which a file is needed
 	 * @throws StorageException If the name is not match the name pattern
 	 */
 	public CleanupRemoteFile(long cleanupNumber) throws StorageException {
 		super(String.format(NAME_FORMAT, Long.toString(cleanupNumber)));
+	}
+
+	public CleanupRemoteFile(long cleanupNumber, String path) throws StorageException {
+		super(String.format(NAME_FORMAT, Long.toString(cleanupNumber)), path);
 	}
 
 	@Override

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/files/DatabaseRemoteFile.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/files/DatabaseRemoteFile.java
@@ -56,6 +56,10 @@ public class DatabaseRemoteFile extends RemoteFile implements Comparable<Databas
 		super(name);
 	}
 
+	public DatabaseRemoteFile(String name, String path) throws StorageException {
+		super(name, path);
+	}
+
 	/**
 	 * Initializes a new database file, given a client name and version
 	 *
@@ -65,6 +69,10 @@ public class DatabaseRemoteFile extends RemoteFile implements Comparable<Databas
 	 */
 	public DatabaseRemoteFile(String clientName, long version) throws StorageException {
 		super(String.format(NAME_FORMAT, clientName, version));
+	}
+
+	public DatabaseRemoteFile(String clientName, long version, String path) throws StorageException {
+		super(String.format(NAME_FORMAT, clientName, version), path);
 	}
 
 	/**

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/files/MasterRemoteFile.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/files/MasterRemoteFile.java
@@ -1,6 +1,6 @@
 /*
  * Syncany, www.syncany.org
- * Copyright (C) 2011-2015 Philipp C. Heckel <philipp.heckel@gmail.com> 
+ * Copyright (C) 2011-2015 Philipp C. Heckel <philipp.heckel@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,12 +21,12 @@ import org.syncany.plugins.transfer.StorageException;
 
 /**
  * The master file represents the file that stores the salt for the master
- * key. The file is only mandatory if the repository is encrypted. 
- * 
+ * key. The file is only mandatory if the repository is encrypted.
+ *
  * <p><b>Name pattern:</b> The file must always be called <b>master</b>
  * Initializing an instance with a different name will throw an
  * exception.
- * 
+ *
  * @author Philipp C. Heckel <philipp.heckel@gmail.com>
  */
 public class MasterRemoteFile extends RemoteFile {
@@ -38,18 +38,22 @@ public class MasterRemoteFile extends RemoteFile {
 	 */
 	public MasterRemoteFile() throws StorageException {
 		super(NAME_FORMAT);
-	}	
-	
+	}
+
 	/**
-	 * Initializes a new master file, given a name. This constructor might 
+	 * Initializes a new master file, given a name. This constructor might
 	 * be called by the {@link RemoteFileFactory#createRemoteFile(String, Class) createRemoteFile()}
-	 * method of the {@link RemoteFileFactory}. 
-	 *  
-	 * @param name Master file name; <b>must</b> always be <b>master</b> 
+	 * method of the {@link RemoteFileFactory}.
+	 *
+	 * @param name Master file name; <b>must</b> always be <b>master</b>
 	 * @throws StorageException If the name is not <b>master</b>
 	 */
 	public MasterRemoteFile(String name) throws StorageException {
 		super(name);
+	}
+
+	public MasterRemoteFile(String name, String path) throws StorageException {
+		super(name, path);
 	}
 
 	@Override
@@ -57,7 +61,7 @@ public class MasterRemoteFile extends RemoteFile {
 		if (!NAME_FORMAT.equals(name)) {
 			throw new StorageException(name + ": remote filename pattern does not match: " + NAME_FORMAT + " expected.");
 		}
-		
+
 		return name;
 	}
 }

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/files/MultichunkRemoteFile.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/files/MultichunkRemoteFile.java
@@ -1,6 +1,6 @@
 /*
  * Syncany, www.syncany.org
- * Copyright (C) 2011-2015 Philipp C. Heckel <philipp.heckel@gmail.com> 
+ * Copyright (C) 2011-2015 Philipp C. Heckel <philipp.heckel@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -25,12 +25,12 @@ import org.syncany.plugins.transfer.StorageException;
 import org.syncany.util.StringUtil;
 
 /**
- * The multichunk file represents a multichunk on the remote storage. 
- * 
+ * The multichunk file represents a multichunk on the remote storage.
+ *
  * <p><b>Name pattern:</b> The name pattern of a multichunk file is
- * <b>multichunk-&lt;multichunkid&gt;</b>. Initializing an 
+ * <b>multichunk-&lt;multichunkid&gt;</b>. Initializing an
  * instance with a non-matching name will throw an exception.
- * 
+ *
  * @author Philipp C. Heckel <philipp.heckel@gmail.com>
  */
 public class MultichunkRemoteFile extends RemoteFile {
@@ -40,28 +40,36 @@ public class MultichunkRemoteFile extends RemoteFile {
 	private byte[] multiChunkId;
 
 	/**
-	 * Initializes a new multichunk file, given a name. This constructor might 
+	 * Initializes a new multichunk file, given a name. This constructor might
 	 * be called by the {@link RemoteFileFactory#createRemoteFile(String, Class) createRemoteFile()}
-	 * method of the {@link RemoteFileFactory}. 
-	 * 
-	 * <p>If the pattern matches, the multichunk identifier is set and can be  
+	 * method of the {@link RemoteFileFactory}.
+	 *
+	 * <p>If the pattern matches, the multichunk identifier is set and can be
 	 * queried by {@link #getMultiChunkId()}.
-	 *  
-	 * @param name Multichunk file name; <b>must</b> always match the {@link #NAME_PATTERN} 
+	 *
+	 * @param name Multichunk file name; <b>must</b> always match the {@link #NAME_PATTERN}
 	 * @throws StorageException If the name is not match the name pattern
 	 */
 	public MultichunkRemoteFile(String name) throws StorageException {
 		super(name);
 	}
 
+	public MultichunkRemoteFile(String name, String path) throws StorageException {
+		super(name, path);
+	}
+
 	/**
 	 * Initializes a new multichunk file, given a multichunk identifier
-	 *  
+	 *
 	 * @param multiChunkId The identifier of the multichunk
 	 * @throws StorageException Never throws an exception
 	 */
 	public MultichunkRemoteFile(MultiChunkId multiChunkId) throws StorageException {
 		super(String.format(NAME_FORMAT, multiChunkId.toString()));
+	}
+
+	public MultichunkRemoteFile(MultiChunkId multiChunkId, String path) throws StorageException {
+		this(String.format(NAME_FORMAT, multiChunkId.toString()), path);
 	}
 
 	/**

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/files/RemoteFile.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/files/RemoteFile.java
@@ -24,6 +24,7 @@ import java.util.logging.Logger;
 import org.syncany.plugins.transfer.StorageException;
 import org.syncany.plugins.transfer.TransferManager;
 import org.syncany.util.StringUtil;
+import com.google.common.base.Objects;
 
 /**
  * A remote file represents a file object on a remote storage. Its purpose is to
@@ -132,12 +133,12 @@ public abstract class RemoteFile {
 	 * <p>The name must match the corresponding name pattern, and the class name
 	 * can either be <tt>RemoteFile</tt>, or a sub-class thereof.
 	 *
-	 * @param path The path of the remote file
 	 * @param name The name of the remote file
+	 * @param path The path of the remote file
 	 * @param remoteFileClass Class name of the object to instantiate, <tt>RemoteFile</tt> or a sub-class thereof
 	 * @return Returns a new object of the given class
 	 */
-	public static <T extends RemoteFile> T createRemoteFileWithPath(String path, String name, Class<T> remoteFileClass) throws StorageException {
+	public static <T extends RemoteFile> T createRemoteFileWithPath(String name, String path, Class<T> remoteFileClass) throws StorageException {
 		try {
 			return remoteFileClass.getConstructor(String.class, String.class).newInstance(name, path);
 		}
@@ -205,6 +206,6 @@ public abstract class RemoteFile {
 
 	@Override
 	public String toString() {
-		return RemoteFile.class.getSimpleName() + "[name=" + name + "]";
+		return Objects.toStringHelper(this).add("name", name).add("path", path).toString();
 	}
 }

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/files/RemoteFile.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/files/RemoteFile.java
@@ -17,6 +17,7 @@
  */
 package org.syncany.plugins.transfer.files;
 
+import java.nio.file.Paths;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -40,11 +41,13 @@ import org.syncany.util.StringUtil;
  */
 public abstract class RemoteFile {
 	private static final Logger logger = Logger.getLogger(RemoteFile.class.getSimpleName());
+	private static final String EMPTY_PATH = "";
 
 	private static final String REMOTE_FILE_PACKAGE = RemoteFile.class.getPackage().getName();
 	private static final String REMOTE_FILE_SUFFIX = RemoteFile.class.getSimpleName();
 
 	private String name;
+	private String path;
 
 	/**
 	 * Creates a new remote file by its name. The name is used by {@link TransferManager}s
@@ -62,13 +65,31 @@ public abstract class RemoteFile {
 	 *         <b>Note:</b> <tt>RemoteFile</tt> does never throw this exceptions, however, subclasses might.
 	 */
 	public RemoteFile(String name) throws StorageException {
+		this(name, EMPTY_PATH);
+	}
+
+	public RemoteFile(String name, String path) throws StorageException {
+		if (path == null) {
+			logger.log(Level.WARNING, "Tried to iniitalized a remotefile with nulled path, use new RemoteFile(String name) instead");
+			path = EMPTY_PATH;
+		}
+
 		this.name = validateName(name);
+		this.path = path;
 	}
 
 	/**
-	 * Returns the name of the file (as it is identified by Syncany)
+	 * Returns the name of the file including its path (as it is identified by Syncany)
+	 * If the file does not have a path, this method is identical to getSimpleName()
 	 */
 	public String getName() {
+		return Paths.get(path, name).normalize().toString();
+	}
+
+	/**
+	 * Returns the name of the file
+	 */
+	public String getSimpleName() {
 		return name;
 	}
 
@@ -99,6 +120,26 @@ public abstract class RemoteFile {
 	public static <T extends RemoteFile> T createRemoteFile(String name, Class<T> remoteFileClass) throws StorageException {
 		try {
 			return remoteFileClass.getConstructor(String.class).newInstance(name);
+		}
+		catch (Exception e) {
+			throw new StorageException(e);
+		}
+	}
+
+	/**
+	 * Creates a remote file based on a path, a name and a class name.
+	 *
+	 * <p>The name must match the corresponding name pattern, and the class name
+	 * can either be <tt>RemoteFile</tt>, or a sub-class thereof.
+	 *
+	 * @param path The path of the remote file
+	 * @param name The name of the remote file
+	 * @param remoteFileClass Class name of the object to instantiate, <tt>RemoteFile</tt> or a sub-class thereof
+	 * @return Returns a new object of the given class
+	 */
+	public static <T extends RemoteFile> T createRemoteFileWithPath(String path, String name, Class<T> remoteFileClass) throws StorageException {
+		try {
+			return remoteFileClass.getConstructor(String.class, String.class).newInstance(name, path);
 		}
 		catch (Exception e) {
 			throw new StorageException(e);

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/files/SyncanyRemoteFile.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/files/SyncanyRemoteFile.java
@@ -1,6 +1,6 @@
 /*
  * Syncany, www.syncany.org
- * Copyright (C) 2011-2015 Philipp C. Heckel <philipp.heckel@gmail.com> 
+ * Copyright (C) 2011-2015 Philipp C. Heckel <philipp.heckel@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,11 +23,11 @@ import org.syncany.plugins.transfer.StorageException;
  * The repo file represents the repository-defining file. It is used to
  * describe the chunking and encryption parameters of an an initialized
  * repository.
- * 
+ *
  * <p><b>Name pattern:</b> The file must always be called <b>syncany</b>
  * Initializing an instance with a different name will throw an
  * exception.
- * 
+ *
  * @author Philipp C. Heckel <philipp.heckel@gmail.com>
  */
 public class SyncanyRemoteFile extends RemoteFile {
@@ -42,15 +42,19 @@ public class SyncanyRemoteFile extends RemoteFile {
 	}
 
 	/**
-	 * Initializes a new repo file, given a name. This constructor might 
+	 * Initializes a new repo file, given a name. This constructor might
 	 * be called by the {@link RemoteFileFactory#createRemoteFile(String, Class) createRemoteFile()}
-	 * method of the {@link RemoteFileFactory}. 
-	 *  
-	 * @param name Repo file name; <b>must</b> always be <b>syncany</b> 
+	 * method of the {@link RemoteFileFactory}.
+	 *
+	 * @param name Repo file name; <b>must</b> always be <b>syncany</b>
 	 * @throws StorageException If the name is not <b>syncany</b>
 	 */
 	public SyncanyRemoteFile(String name) throws StorageException {
 		super(name);
+	}
+
+	public SyncanyRemoteFile(String name, String path) throws StorageException {
+		super(name, path);
 	}
 
 	@Override

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/files/TempRemoteFile.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/files/TempRemoteFile.java
@@ -1,6 +1,6 @@
 /*
  * Syncany, www.syncany.org
- * Copyright (C) 2011-2015 Philipp C. Heckel <philipp.heckel@gmail.com> 
+ * Copyright (C) 2011-2015 Philipp C. Heckel <philipp.heckel@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,11 +24,11 @@ import org.syncany.crypto.CipherUtil;
 import org.syncany.plugins.transfer.StorageException;
 
 /**
- * The temp file represents a temporary file on the remote storage. 
- * 
+ * The temp file represents a temporary file on the remote storage.
+ *
  * <p><b>Name pattern:</b> The name pattern of a temp file is
  * <b>temp-&lt;randomidentifier&gt;</b>.
- * 
+ *
  * @author Pim Otte
  */
 public class TempRemoteFile extends RemoteFile {
@@ -36,26 +36,34 @@ public class TempRemoteFile extends RemoteFile {
 	private static final String NAME_FORMAT = "temp-%s-%s";
 
 	private RemoteFile targetRemoteFile;
-	
+
 	/**
-	 * Initializes a new temp file, given a name. 
-	 * 
-	 * @param name temp file name; <b>must</b> always match the {@link #NAME_PATTERN} 
+	 * Initializes a new temp file, given a name.
+	 *
+	 * @param name temp file name; <b>must</b> always match the {@link #NAME_PATTERN}
 	 * @throws StorageException If the name is not match the name pattern
 	 */
 	public TempRemoteFile(String name) throws StorageException {
 		super(name);
 	}
-	
+
+	public TempRemoteFile(String name, String path) throws StorageException {
+		super(name, path);
+	}
+
 	/**
 	 * Initializes a new randomly named temp file.
-	 * 
+	 *
 	 * @throws StorageException
 	 */
 	public TempRemoteFile(RemoteFile targetRemoteFile) throws StorageException {
 		super(String.format(NAME_FORMAT, CipherUtil.createRandomAlphabeticString(5), targetRemoteFile.getName()));
 	}
-	
+
+	public TempRemoteFile(RemoteFile targetRemoteFile, String path) throws StorageException {
+		super(String.format(NAME_FORMAT, CipherUtil.createRandomAlphabeticString(5), targetRemoteFile.getName()), path);
+	}
+
 	/**
 	 * Returns the target remote file, i.e. the {@link RemoteFile} this
 	 * temporary file will be renamed into, or was renamed from.
@@ -71,7 +79,7 @@ public class TempRemoteFile extends RemoteFile {
 		if (!matcher.matches()) {
 			throw new StorageException(name + ": remote filename pattern does not match: " + NAME_PATTERN.pattern() + " expected.");
 		}
-		
+
 		try {
 			targetRemoteFile = RemoteFile.createRemoteFile(matcher.group(2));
 		}

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/files/TempRemoteFile.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/files/TempRemoteFile.java
@@ -57,11 +57,11 @@ public class TempRemoteFile extends RemoteFile {
 	 * @throws StorageException
 	 */
 	public TempRemoteFile(RemoteFile targetRemoteFile) throws StorageException {
-		super(String.format(NAME_FORMAT, CipherUtil.createRandomAlphabeticString(5), targetRemoteFile.getName()));
+		super(String.format(NAME_FORMAT, CipherUtil.createRandomAlphabeticString(5), targetRemoteFile.getSimpleName()));
 	}
 
 	public TempRemoteFile(RemoteFile targetRemoteFile, String path) throws StorageException {
-		super(String.format(NAME_FORMAT, CipherUtil.createRandomAlphabeticString(5), targetRemoteFile.getName()), path);
+		super(String.format(NAME_FORMAT, CipherUtil.createRandomAlphabeticString(5), targetRemoteFile.getSimpleName()), path);
 	}
 
 	/**

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/files/TransactionRemoteFile.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/files/TransactionRemoteFile.java
@@ -1,6 +1,6 @@
 /*
  * Syncany, www.syncany.org
- * Copyright (C) 2011-2015 Philipp C. Heckel <philipp.heckel@gmail.com> 
+ * Copyright (C) 2011-2015 Philipp C. Heckel <philipp.heckel@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,11 +24,11 @@ import org.syncany.plugins.transfer.RemoteTransaction;
 import org.syncany.plugins.transfer.StorageException;
 
 /**
- * The transaction file represents a manifest of a transaction on the remote storage. 
- * 
+ * The transaction file represents a manifest of a transaction on the remote storage.
+ *
  * <p><b>Name pattern:</b> The name pattern of a transaction file is
  * <b>transaction-&lt;filehexhashcode&gt;</b>.
- * 
+ *
  * @author Pim Otte
  */
 public class TransactionRemoteFile extends RemoteFile {
@@ -36,23 +36,31 @@ public class TransactionRemoteFile extends RemoteFile {
 	private static final String NAME_FORMAT = "transaction-%s";
 
 	/**
-	 * Initializes a new transaction file, given a name. 
-	 * 
-	 * @param name transaction file name; <b>must</b> always match the {@link #NAME_PATTERN} 
+	 * Initializes a new transaction file, given a name.
+	 *
+	 * @param name transaction file name; <b>must</b> always match the {@link #NAME_PATTERN}
 	 * @throws StorageException If the name is not match the name pattern
 	 */
 	public TransactionRemoteFile(String name) throws StorageException {
 		super(name);
 	}
 
+	public TransactionRemoteFile(String name, String path) throws StorageException {
+		super(name, path);
+	}
+
 	/**
 	 * Initializes a new transaction file, given the transaction itself.
-	 * 
+	 *
 	 * @param remoteTransaction the remoteTransaction for which a file is needed
 	 * @throws StorageException If the name is not match the name pattern
 	 */
 	public TransactionRemoteFile(RemoteTransaction remoteTransaction) throws StorageException {
 		super(String.format(NAME_FORMAT, Integer.toHexString(remoteTransaction.hashCode())));
+	}
+
+	public TransactionRemoteFile(RemoteTransaction remoteTransaction, String path) throws StorageException {
+		super(String.format(NAME_FORMAT, Integer.toHexString(remoteTransaction.hashCode())), path);
 	}
 
 	@Override


### PR DESCRIPTION
As discussed in #361 and #353 some repos require us to breakdown many files into different subfolders. Hence, I started to provide a subfolder based TM which handles this stuff (based on @pimotte's idea).

So if a plugin wants to take advantage of this approach, its TransferManager has to implement Folderable. This signalises Syncany to wrap the plugin's TransferManager in a FolderAwareTransferManager which handles the subfoldering stuff based on properties provided by a plugin (a plugin dev can choose if he either wants to use hard coded properties or lets a user choose them).

The TransferManager has to take care of the listing and cleanup stuff (like the removal of empty directories), though. I think this is too plugin specific.

Example usage is shown in this [syncany-plugin-dropbox branch](https://github.com/syncany/syncany-plugin-dropbox/tree/feature/folderizable).

I already tested it for a short time but I'd really appreciate if someone could also check if it works as expected.

**Request for review**

closes #365