### PR TITLE
Some unit tests for the daemon package

### DIFF
--- a/syncany-lib/build.gradle
+++ b/syncany-lib/build.gradle
@@ -27,5 +27,6 @@ dependencies {
 	compile			"com.google.code.gson:gson:2.3"
 
 	testCompile		project(path: ':syncany-util', configuration: 'tests')
+	testCompile		"org.mockito:mockito-all:1.10.19"	
 	testCompile		"junit:junit:4.9"
 }

--- a/syncany-lib/src/main/java/org/syncany/operations/daemon/ControlServer.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/daemon/ControlServer.java
@@ -59,6 +59,15 @@ public class ControlServer implements TailerListener {
 		this.controlFileTailer = new Tailer(controlFile, this, 1000, true);
 		this.eventBus = LocalEventBus.getInstance();		
 	}
+	
+	/**
+	 * Constructor required for unit testing, as you can inject mocks in this way.
+	 */
+	public ControlServer(File ctrlFile, Tailer ctrTailer, LocalEventBus eventBus) {
+		this.controlFile = ctrlFile;
+		this.controlFileTailer = ctrTailer;
+		this.eventBus = eventBus;
+	}
 
 	public void enterLoop() throws IOException, ServiceAlreadyStartedException {
 		File userAppDir = UserConfig.getUserConfigDir();

--- a/syncany-lib/src/main/java/org/syncany/operations/daemon/ControlServer.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/daemon/ControlServer.java
@@ -63,6 +63,7 @@ public class ControlServer implements TailerListener {
 	/**
 	 * Constructor required for unit testing, as you can inject mocks in this way.
 	 */
+	@Deprecated
 	public ControlServer(File ctrlFile, Tailer ctrTailer, LocalEventBus eventBus) {
 		this.controlFile = ctrlFile;
 		this.controlFileTailer = ctrTailer;

--- a/syncany-lib/src/test/unit/java/org/syncany/tests/unit/operations/deamon/ControlServerTest.java
+++ b/syncany-lib/src/test/unit/java/org/syncany/tests/unit/operations/deamon/ControlServerTest.java
@@ -1,0 +1,110 @@
+/*
+ * Syncany, www.syncany.org
+ * Copyright (C) 2011-2015 Philipp C. Heckel <philipp.heckel@gmail.com> 
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.syncany.tests.unit.operations.deamon;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.io.input.Tailer;
+import org.junit.Before;
+import org.junit.Test;
+import org.syncany.config.LocalEventBus;
+import org.syncany.operations.daemon.ControlServer;
+import org.syncany.operations.daemon.ControlServer.ControlCommand;
+import org.syncany.operations.daemon.ServiceAlreadyStartedException;
+
+/**
+ * Unit tests for the {@link org.syncany.operations.daemon.ControlServer} class, 
+ * using Mockito for mocking its instance variables.
+ * 
+ * @author Niels Spruit
+ *
+ */
+public class ControlServerTest {
+
+	private ControlServer ctrlServer;
+	private File ctrlFile;
+	private Tailer ctrlFileTailer;
+	private LocalEventBus eventBus;
+
+	@Before
+	public void setUp() {
+		ctrlFile = mock(File.class);
+		ctrlFileTailer = mock(Tailer.class);
+		eventBus = mock(LocalEventBus.class);
+		ctrlServer = new ControlServer(ctrlFile, ctrlFileTailer, eventBus);
+	}
+
+	@Test
+	public void testEnterLoop() throws IOException, ServiceAlreadyStartedException {
+		// invoke method
+		ctrlServer.enterLoop();
+
+		// verify interactions
+		verify(ctrlFile).delete();
+		verify(ctrlFile).createNewFile();
+		verify(ctrlFile).deleteOnExit();
+		verify(ctrlFileTailer).run();
+	}
+
+	@Test
+	public void testHandleShutdown() {
+		ctrlServer.handle("SHUTDOWN");
+
+		verifyZeroInteractions(ctrlFile);
+		verify(eventBus).post(ControlCommand.SHUTDOWN);
+		verifyNoMoreInteractions(eventBus);
+		verify(ctrlFileTailer).stop();
+		verifyNoMoreInteractions(ctrlFileTailer);
+	}
+
+	@Test
+	public void testHandleReload() {
+		ctrlServer.handle("RELOAD");
+
+		verifyZeroInteractions(ctrlFile);
+		verifyZeroInteractions(ctrlFileTailer);
+		verify(eventBus).post(ControlCommand.RELOAD);
+		verifyNoMoreInteractions(eventBus);
+	}
+
+	@Test
+	public void testHandleUnknownCommand() {
+		ctrlServer.handle("UnknownCommand");
+
+		verifyZeroInteractions(ctrlFile);
+		verifyZeroInteractions(ctrlFileTailer);
+		verifyZeroInteractions(eventBus);
+	}
+
+	@Test(expected = RuntimeException.class)
+	public void testFileNotFound() {
+		ctrlServer.fileNotFound();
+	}
+
+	@Test(expected = RuntimeException.class)
+	public void testHandle() {
+		ctrlServer.handle(new Exception());
+	}
+
+}

--- a/syncany-lib/src/test/unit/java/org/syncany/tests/unit/operations/deamon/DaemonOperationOptionsTest.java
+++ b/syncany-lib/src/test/unit/java/org/syncany/tests/unit/operations/deamon/DaemonOperationOptionsTest.java
@@ -1,0 +1,86 @@
+/*
+ * Syncany, www.syncany.org
+ * Copyright (C) 2011-2015 Philipp C. Heckel <philipp.heckel@gmail.com> 
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.syncany.tests.unit.operations.deamon;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.syncany.operations.daemon.DaemonOperationOptions;
+import org.syncany.operations.daemon.DaemonOperationOptions.DaemonAction;
+
+/**
+ * Unit tests for the {@link DaemonOperationOptions} class.
+ * 
+ * @author Niels Spruit
+ *
+ */
+public class DaemonOperationOptionsTest {
+
+	private DaemonOperationOptions options;
+
+	@Before
+	public void setUp() {
+		options = new DaemonOperationOptions(DaemonAction.ADD);
+	}
+
+	@Test
+	public void testGetAction() {
+		DaemonAction res = options.getAction();
+		assertNotNull(res);
+		assertEquals(DaemonAction.ADD, res);
+	}
+
+	@Test
+	public void testSetAction() {
+		options.setAction(DaemonAction.LIST);
+		assertNotNull(options.getAction());
+		assertEquals(DaemonAction.LIST, options.getAction());
+	}
+
+	@Test
+	public void testGetWatchRoots() {
+		options = new DaemonOperationOptions();
+
+		List<String> res = options.getWatchRoots();
+		assertNotNull(res);
+		assertTrue(res.isEmpty());
+	}
+
+	@Test
+	public void testSetWatchRoots() {
+		options = new DaemonOperationOptions();
+
+		List<String> watchRoots = new ArrayList<String>();
+		watchRoots.add("root1");
+		watchRoots.add("root2");
+		options.setWatchRoots(watchRoots);
+
+		List<String> res = options.getWatchRoots();
+		assertNotNull(res);
+		assertFalse(res.isEmpty());
+		assertTrue(res.contains("root1"));
+		assertTrue(res.contains("root2"));
+	}
+}

--- a/syncany-lib/src/test/unit/java/org/syncany/tests/unit/operations/deamon/DaemonOperationResultTest.java
+++ b/syncany-lib/src/test/unit/java/org/syncany/tests/unit/operations/deamon/DaemonOperationResultTest.java
@@ -1,0 +1,85 @@
+/*
+ * Syncany, www.syncany.org
+ * Copyright (C) 2011-2015 Philipp C. Heckel <philipp.heckel@gmail.com> 
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.syncany.tests.unit.operations.deamon;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.syncany.config.to.FolderTO;
+import org.syncany.operations.daemon.DaemonOperationResult;
+import org.syncany.operations.daemon.DaemonOperationResult.DaemonResultCode;
+
+/**
+ * Unit tests for the {@link DaemonOperationResult} class.
+ * 
+ * @author Niels Spruit
+ *
+ */
+public class DaemonOperationResultTest {
+
+	private DaemonOperationResult result;
+	private FolderTO folder;
+	private ArrayList<FolderTO> watchList;
+
+	@Before
+	public void setUp() {
+		folder = new FolderTO("test");
+		watchList = new ArrayList<FolderTO>();
+		watchList.add(folder);
+		result = new DaemonOperationResult(DaemonResultCode.OK, watchList);
+	}
+
+	@Test
+	public void testGetResultCode() {
+		DaemonResultCode res = result.getResultCode();
+		assertNotNull(res);
+		assertEquals(DaemonResultCode.OK, res);
+	}
+
+	@Test
+	public void testSetResultCode() {
+		result.setResultCode(DaemonResultCode.NOK);
+		DaemonResultCode res = result.getResultCode();
+		assertNotNull(res);
+		assertEquals(DaemonResultCode.NOK, res);
+	}
+
+	@Test
+	public void testGetWatchList() {
+		ArrayList<FolderTO> res = result.getWatchList();
+		assertNotNull(res);
+		assertFalse(res.isEmpty());
+		assertTrue(res.contains(folder));
+	}
+
+	@Test
+	public void setWatchList() {
+		ArrayList<FolderTO> newList = new ArrayList<FolderTO>();
+		result.setWatchList(newList);
+		ArrayList<FolderTO> res = result.getWatchList();
+		assertNotNull(res);
+		assertTrue(res.isEmpty());
+	}
+
+}

--- a/syncany-lib/src/test/unit/java/org/syncany/tests/unit/operations/deamon/DaemonOperationTest.java
+++ b/syncany-lib/src/test/unit/java/org/syncany/tests/unit/operations/deamon/DaemonOperationTest.java
@@ -1,0 +1,103 @@
+/*
+ * Syncany, www.syncany.org
+ * Copyright (C) 2011-2015 Philipp C. Heckel <philipp.heckel@gmail.com> 
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.syncany.tests.unit.operations.deamon;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.syncany.config.Config;
+import org.syncany.operations.daemon.DaemonOperation;
+import org.syncany.operations.daemon.DaemonOperationOptions;
+import org.syncany.operations.daemon.DaemonOperationOptions.DaemonAction;
+import org.syncany.operations.daemon.DaemonOperationResult;
+import org.syncany.operations.daemon.DaemonOperationResult.DaemonResultCode;
+
+/**
+ * Unit tests for the {@link DaemonOperation} class, 
+ * using Mockito for mocking its instance variable options.
+ * 
+ * @author Niels Spruit
+ *
+ */
+public class DaemonOperationTest {
+
+	private DaemonOperationOptions options;
+	private DaemonOperation deamonOp;
+
+	private final String WATCH_ROOT_FOLDER = "watch_root_folder";
+	private final String WATCH_ROOT_APP_FOLDER = "watch_root_folder/" + Config.DIR_APPLICATION;
+
+	@Before
+	public void setUp() {
+		options = mock(DaemonOperationOptions.class);
+		deamonOp = new DaemonOperation(options);
+		new File(WATCH_ROOT_APP_FOLDER).mkdirs();
+	}
+
+	@Test
+	public void testExecuteList() throws Exception {
+		when(options.getAction()).thenReturn(DaemonAction.LIST);
+
+		DaemonOperationResult res = deamonOp.execute();
+		assertNotNull(res);
+		assertEquals(DaemonResultCode.OK, res.getResultCode());
+		assertNotNull(res.getWatchList());
+	}
+
+	@Test
+	public void testExecuteAdd() throws Exception {
+		when(options.getAction()).thenReturn(DaemonAction.ADD);
+
+		List<String> watchRoots = new ArrayList<String>();
+		watchRoots.add(WATCH_ROOT_FOLDER);
+		when(options.getWatchRoots()).thenReturn(watchRoots);
+
+		DaemonOperationResult res = deamonOp.execute();
+
+		assertNotNull(res);
+		assertEquals(DaemonResultCode.NOK, res.getResultCode());
+		assertNotNull(res.getWatchList());
+		assertEquals(1, res.getWatchList().size());
+		assertEquals(new File(WATCH_ROOT_FOLDER).getAbsolutePath(), res.getWatchList().get(0).getPath());
+	}
+
+	@Test
+	public void testExecuteRemove() throws Exception {
+		when(options.getAction()).thenReturn(DaemonAction.REMOVE);
+
+		List<String> watchRoots = new ArrayList<String>();
+		watchRoots.add(WATCH_ROOT_FOLDER);
+		when(options.getWatchRoots()).thenReturn(watchRoots);
+
+		DaemonOperationResult res = deamonOp.execute();
+
+		assertNotNull(res);
+		assertEquals(DaemonResultCode.OK, res.getResultCode());
+		assertNotNull(res.getWatchList());
+		assertTrue(res.getWatchList().isEmpty());
+	}
+}

--- a/syncany-lib/src/test/unit/java/org/syncany/tests/unit/operations/deamon/DaemonOperationTest.java
+++ b/syncany-lib/src/test/unit/java/org/syncany/tests/unit/operations/deamon/DaemonOperationTest.java
@@ -37,6 +37,7 @@ import org.syncany.operations.daemon.DaemonOperationOptions;
 import org.syncany.operations.daemon.DaemonOperationOptions.DaemonAction;
 import org.syncany.operations.daemon.DaemonOperationResult;
 import org.syncany.operations.daemon.DaemonOperationResult.DaemonResultCode;
+import org.syncany.tests.unit.util.TestFileUtil;
 
 /**
  * Unit tests for the {@link DaemonOperation} class, 
@@ -50,13 +51,12 @@ public class DaemonOperationTest {
 	private DaemonOperationOptions options;
 	private DaemonOperation deamonOp;
 
-	private static final String WATCH_ROOT_FOLDER = "watch_root_folder";
 	private static final String WATCH_ROOT_APP_FOLDER = "watch_root_folder/" + Config.DIR_APPLICATION;
+	private static File tempWatchRootAppFolder;
 
 	@BeforeClass
-	public static void initialize() {
-		//create required folder
-		new File(WATCH_ROOT_APP_FOLDER).mkdirs();
+	public static void initialize() throws Exception {
+		tempWatchRootAppFolder = TestFileUtil.createTempDirectoryInSystemTemp(WATCH_ROOT_APP_FOLDER);
 	}
 
 	@Before
@@ -80,16 +80,16 @@ public class DaemonOperationTest {
 		when(options.getAction()).thenReturn(DaemonAction.ADD);
 
 		List<String> watchRoots = new ArrayList<String>();
-		watchRoots.add(WATCH_ROOT_FOLDER);
+		watchRoots.add(tempWatchRootAppFolder.getParent());
 		when(options.getWatchRoots()).thenReturn(watchRoots);
 
 		DaemonOperationResult res = deamonOp.execute();
 
 		assertNotNull(res);
-		assertEquals(DaemonResultCode.NOK, res.getResultCode());
+		assertEquals(DaemonResultCode.OK, res.getResultCode());
 		assertNotNull(res.getWatchList());
 		assertEquals(1, res.getWatchList().size());
-		assertEquals(new File(WATCH_ROOT_FOLDER).getAbsolutePath(), res.getWatchList().get(0).getPath());
+		assertEquals(tempWatchRootAppFolder.getParentFile().getAbsolutePath(), res.getWatchList().get(0).getPath());
 	}
 
 	@Test
@@ -97,7 +97,7 @@ public class DaemonOperationTest {
 		when(options.getAction()).thenReturn(DaemonAction.REMOVE);
 
 		List<String> watchRoots = new ArrayList<String>();
-		watchRoots.add(WATCH_ROOT_FOLDER);
+		watchRoots.add(tempWatchRootAppFolder.getParent());
 		when(options.getWatchRoots()).thenReturn(watchRoots);
 
 		DaemonOperationResult res = deamonOp.execute();
@@ -111,7 +111,7 @@ public class DaemonOperationTest {
 	@AfterClass
 	public static void cleanUp() {
 		// remove created folders
-		new File(WATCH_ROOT_FOLDER).delete();
+		TestFileUtil.deleteDirectory(tempWatchRootAppFolder.getParentFile());
 	}
 
 }

--- a/syncany-lib/src/test/unit/java/org/syncany/tests/unit/operations/deamon/DaemonOperationTest.java
+++ b/syncany-lib/src/test/unit/java/org/syncany/tests/unit/operations/deamon/DaemonOperationTest.java
@@ -27,7 +27,9 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.syncany.config.Config;
 import org.syncany.operations.daemon.DaemonOperation;
@@ -48,14 +50,19 @@ public class DaemonOperationTest {
 	private DaemonOperationOptions options;
 	private DaemonOperation deamonOp;
 
-	private final String WATCH_ROOT_FOLDER = "watch_root_folder";
-	private final String WATCH_ROOT_APP_FOLDER = "watch_root_folder/" + Config.DIR_APPLICATION;
+	private static final String WATCH_ROOT_FOLDER = "watch_root_folder";
+	private static final String WATCH_ROOT_APP_FOLDER = "watch_root_folder/" + Config.DIR_APPLICATION;
+
+	@BeforeClass
+	public static void initialize() {
+		//create required folder
+		new File(WATCH_ROOT_APP_FOLDER).mkdirs();
+	}
 
 	@Before
 	public void setUp() {
 		options = mock(DaemonOperationOptions.class);
 		deamonOp = new DaemonOperation(options);
-		new File(WATCH_ROOT_APP_FOLDER).mkdirs();
 	}
 
 	@Test
@@ -100,4 +107,11 @@ public class DaemonOperationTest {
 		assertNotNull(res.getWatchList());
 		assertTrue(res.getWatchList().isEmpty());
 	}
+
+	@AfterClass
+	public static void cleanUp() {
+		// remove created folders
+		new File(WATCH_ROOT_FOLDER).delete();
+	}
+
 }

--- a/syncany-lib/src/test/unit/java/org/syncany/tests/unit/operations/deamon/WatchTest.java
+++ b/syncany-lib/src/test/unit/java/org/syncany/tests/unit/operations/deamon/WatchTest.java
@@ -1,0 +1,62 @@
+/*
+ * Syncany, www.syncany.org
+ * Copyright (C) 2011-2015 Philipp C. Heckel <philipp.heckel@gmail.com> 
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.syncany.tests.unit.operations.deamon;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.File;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.syncany.operations.daemon.Watch;
+import org.syncany.operations.daemon.Watch.SyncStatus;
+
+/**
+ * Unit tests for the {@link Watch} class.
+ * 
+ * @author Niels Spruit
+ *
+ */
+public class WatchTest {
+
+	private Watch watch;
+	private File folder;
+	private SyncStatus status;
+
+	@Before
+	public void setUp() {
+		folder = new File("test");
+		status = SyncStatus.SYNCING;
+		watch = new Watch(folder, status);
+	}
+
+	@Test
+	public void testGetFolder() {
+		File res = watch.getFolder();
+		assertNotNull(res);
+		assertEquals(folder, res);
+	}
+
+	@Test
+	public void testGetStatus() {
+		SyncStatus res = watch.getStatus();
+		assertNotNull(res);
+		assertEquals(status, res);
+	}
+}


### PR DESCRIPTION
Hi,

As indicated in issue #384, the daemon package is lacking coverage. To improve this I've created some small and simple unit tests for the following classes: `ControlServer`, `DaemonOperation`, `DaemonOperationOptions`, `DaemonOperationResult` and `Watch`. The tests use Mockito to mock external dependencies and thereby the classes can be tested in isolation. 

Let me know what you think.
