### PR TITLE
Added no-delete option

### DIFF
--- a/gradle/bash/syncany.bash-completion
+++ b/gradle/bash/syncany.bash-completion
@@ -230,7 +230,8 @@ _sy() {
 		-t --target"
 
 	STATUS_OPTIONS="\
-		-f --force-checksum"
+		-f --force-checksum\
+		-D --no-delete"
 
 	UP_OPTIONS="\
 		-R --no-resume\

--- a/syncany-cli/src/main/java/org/syncany/cli/CommandLineClient.java
+++ b/syncany-cli/src/main/java/org/syncany/cli/CommandLineClient.java
@@ -140,7 +140,7 @@ public class CommandLineClient extends Client {
 			OptionSpec<String> optionLog = parser.acceptsAll(asList("log")).withRequiredArg();
 			OptionSpec<Void> optionLogPrint = parser.acceptsAll(asList("print"));
 			OptionSpec<String> optionLogLevel = parser.acceptsAll(asList("loglevel")).withOptionalArg();
-			OptionSpec<Void> optionDebug = parser.acceptsAll(asList("D", "debug"));
+			OptionSpec<Void> optionDebug = parser.acceptsAll(asList("d", "debug"));
 			OptionSpec<Void> optionShortVersion = parser.acceptsAll(asList("v"));
 			OptionSpec<Void> optionFullVersion = parser.acceptsAll(asList("vv"));
 

--- a/syncany-cli/src/main/java/org/syncany/cli/StatusCommand.java
+++ b/syncany-cli/src/main/java/org/syncany/cli/StatusCommand.java
@@ -58,11 +58,15 @@ public class StatusCommand extends Command {
 		parser.allowsUnrecognizedOptions();
 		
 		OptionSpec<Void> optionForceChecksum = parser.acceptsAll(asList("f", "force-checksum"));
+		OptionSpec<Void> optionNoDeleteUpload = parser.acceptsAll(asList("D", "no-delete"));
 		
 		OptionSet options = parser.parse(operationArgs);	
 		
 		// --force-checksum
 		operationOptions.setForceChecksum(options.has(optionForceChecksum));
+		
+		// -D, --no-delete
+		operationOptions.setDelete(!options.has(optionNoDeleteUpload));
 		
 		return operationOptions;
 	}	

--- a/syncany-cli/src/main/resources/org/syncany/cli/cmd/help.status.skel
+++ b/syncany-cli/src/main/resources/org/syncany/cli/cmd/help.status.skel
@@ -2,7 +2,7 @@ NAME
   sy-status - list new and changed files in local Syncany folder
     
 SYNOPSIS
-  sy status [-f | --force-checksum]
+  sy status [-f | --force-checksum] [-D | --no-delete]
   
 DESCRIPTION
   This command compares the local file tree on the disk with the local
@@ -25,7 +25,7 @@ OPTIONS
     decrease the performance of this command and increase I/O significantly.
 
   -D, --no-delete
-    With tihs option, locally deleted files will be ignored. This option
+    With this option, locally deleted files will be ignored. This option
     should be used if files in the remote repository should not be deleted
     if missing on the local machine.
     

--- a/syncany-cli/src/main/resources/org/syncany/cli/cmd/help.status.skel
+++ b/syncany-cli/src/main/resources/org/syncany/cli/cmd/help.status.skel
@@ -2,28 +2,33 @@ NAME
   sy-status - list new and changed files in local Syncany folder
     
 SYNOPSIS
-  sy status [-f | --force-checksum] 
+  sy status [-f | --force-checksum]
   
-DESCRIPTION 
+DESCRIPTION
   This command compares the local file tree on the disk with the local
   database and detects local changes. These changes are printed to the
   console.
   
   Local changes are detected using the last modified date and the file size
   of a file. If they match the local database, the command assumes that the
-  content has not changed (no checksum comparison). If -f is enabled, the 
+  content has not changed (no checksum comparison). If -f is enabled, the
   checksum is additionally compared.
   
-  This command is used by the 'up' command to detect local changes.  
+  This command is used by the 'up' command to detect local changes.
   
 OPTIONS
   -f, --force-checksum
     Enforces this command to compare files by checksum, not by file size
     and last modified date only. This option is particularly useful if
-    files are modified in-place very often (last modified date and size 
+    files are modified in-place very often (last modified date and size
     do not change). For large local folders, this option can tremendously
-    decrease the performance of this command and increase I/O significantly.  
- 
+    decrease the performance of this command and increase I/O significantly.
+
+  -D, --no-delete
+    With tihs option, locally deleted files will be ignored. This option
+    should be used if files in the remote repository should not be deleted
+    if missing on the local machine.
+    
 COPYRIGHT
   Syncany %applicationVersionFull%, Distributed under GPLv3,
   Copyright (c) 2011-2015 Philipp C. Heckel

--- a/syncany-cli/src/main/resources/org/syncany/cli/cmd/help.status.skel
+++ b/syncany-cli/src/main/resources/org/syncany/cli/cmd/help.status.skel
@@ -25,9 +25,8 @@ OPTIONS
     decrease the performance of this command and increase I/O significantly.
 
   -D, --no-delete
-    With this option, locally deleted files will be ignored. This option
-    should be used if files in the remote repository should not be deleted
-    if missing on the local machine.
+    With this option, this command will not list locally deleted files. If
+    used with the 'up' command, these changes will not be uploaded.
     
 COPYRIGHT
   Syncany %applicationVersionFull%, Distributed under GPLv3,

--- a/syncany-cli/src/test/integration/java/org/syncany/tests/integration/cli/StatusCommandTest.java
+++ b/syncany-cli/src/test/integration/java/org/syncany/tests/integration/cli/StatusCommandTest.java
@@ -18,7 +18,6 @@
 package org.syncany.tests.integration.cli;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -27,7 +26,6 @@ import java.util.Map;
 import org.junit.Test;
 import org.syncany.cli.CommandLineClient;
 import org.syncany.config.Config;
-import org.syncany.plugins.transfer.files.DatabaseRemoteFile;
 import org.syncany.tests.unit.util.TestCliUtil;
 import org.syncany.tests.util.TestConfigUtil;
 

--- a/syncany-cli/src/test/integration/java/org/syncany/tests/integration/cli/UpCommandTest.java
+++ b/syncany-cli/src/test/integration/java/org/syncany/tests/integration/cli/UpCommandTest.java
@@ -132,6 +132,7 @@ public class UpCommandTest {
 		assertTrue(cliOut[5].contains("Sync down finished"));
 
 		TestCliUtil.deleteTestLocalConfigAndData(clientA);
+		TestCliUtil.deleteTestLocalConfigAndData(clientB);
 	}
 
 	@Test

--- a/syncany-lib/src/main/java/org/syncany/operations/status/StatusOperation.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/status/StatusOperation.java
@@ -83,6 +83,10 @@ public class StatusOperation extends Operation {
 			logger.log(Level.INFO, "Force checksum ENABLED.");
 		}
 		
+		if (options != null && !options.isDelete()) {
+			logger.log(Level.INFO, "Delete missing files DISABLED.");
+		}
+		
 		// Get local database
 		logger.log(Level.INFO, "Querying current file tree from database ...");				
 		eventBus.post(new StatusStartSyncExternalEvent(config.getLocalDir().getAbsolutePath()));		
@@ -109,7 +113,10 @@ public class StatusOperation extends Operation {
 
 	private ChangeSet findLocalChanges(final Map<String, FileVersion> filesInDatabase) throws FileNotFoundException, IOException {
 		ChangeSet localChanges = findLocalChangedAndNewFiles(config.getLocalDir(), filesInDatabase);
-		findAndAppendDeletedFiles(localChanges, filesInDatabase);
+		
+		if (options == null || options.isDelete()) {
+			findAndAppendDeletedFiles(localChanges, filesInDatabase);
+		}
 		
 		return localChanges;
 	}		

--- a/syncany-lib/src/main/java/org/syncany/operations/status/StatusOperationOptions.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/status/StatusOperationOptions.java
@@ -26,11 +26,22 @@ public class StatusOperationOptions implements OperationOptions {
 	@Element(required = false)
 	private boolean forceChecksum = false;
 
+	@Element(required = false)
+	private boolean delete = true;
+
 	public boolean isForceChecksum() {
 		return forceChecksum;
 	}
 
 	public void setForceChecksum(boolean forceChecksum) {
 		this.forceChecksum = forceChecksum;
-	}				
+	}
+	
+	public boolean isDelete() {
+		return delete;
+	}
+
+	public void setDelete(boolean delete) {
+		this.delete = delete;
+	}
 }


### PR DESCRIPTION
Added ‘-d’ or ‘--no-delete’ option for status command as suggested in
#263.  Locally deleted files can be ignored and not synced to the
remote repository.

Fixed debug option to be ‘-d’ instead of ‘-D’