### PR TITLE
Append snapshot flag to updatefile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+### Syncany 0.4.5-alpha (Date: tba)
+- Developer/alpha release (**We are now nearing the beta phase. Stay tuned!**)
+- Bugfixes and other things:
+  + Make sure that plugin update on Windows is able to install snapshots #418
+
+
 ### Syncany 0.4.4-alpha (Date: 22 Mar 2015)
 - Developer/alpha release (**We are now nearing the beta phase. Stay tuned!**)
 - Features and significant changes:

--- a/syncany-lib/src/main/java/org/syncany/operations/plugin/PluginOperation.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/plugin/PluginOperation.java
@@ -93,7 +93,7 @@ public class PluginOperation extends Operation {
 
 	private static final String API_DEFAULT_ENDPOINT_URL = "https://api.syncany.org/v3";
 	private static final String API_PLUGIN_LIST_REQUEST_FORMAT = "%s/plugins/list?appVersion=%s&snapshots=%s&pluginId=%s&os=%s&arch=%s";
-	
+
 	private static final String PURGEFILE_FILENAME = "purgefile";
 	private static final String UPDATE_FILENAME = "updatefile";
 
@@ -113,7 +113,7 @@ public class PluginOperation extends Operation {
 
 	@Override
 	public PluginOperationResult execute() throws Exception {
-		result.setAction(options.getAction());		
+		result.setAction(options.getAction());
 
 		switch (options.getAction()) {
 			case LIST:
@@ -170,7 +170,7 @@ public class PluginOperation extends Operation {
 				File updatefilePath = new File(UserConfig.getUserConfigDir(), UPDATE_FILENAME);
 
 				try (PrintWriter out = new PrintWriter(new BufferedWriter(new FileWriter(updatefilePath, true)))) {
-					out.println(pluginId);
+					out.println(pluginId + (options.isSnapshots() ?  " --snapshot" : ""));
 					delayedPlugins.add(pluginId);
 				}
 				catch (IOException e) {
@@ -561,7 +561,7 @@ public class PluginOperation extends Operation {
 					boolean localVersionOutdated = localVersion.lessThan(remoteVersion);
 					boolean applicationVersionCompatible = applicationVersion.greaterThanOrEqualTo(remoteMinAppVersion);
 					boolean pluginIsOutdated = localVersionOutdated && applicationVersionCompatible;
-					
+
 					extendedPluginInfo.setOutdated(pluginIsOutdated);
 				}
 
@@ -620,7 +620,7 @@ public class PluginOperation extends Operation {
 
 		String apiEndpointUrl = (options.getApiEndpoint() != null) ? options.getApiEndpoint() : API_DEFAULT_ENDPOINT_URL;
 		URL pluginListUrl = new URL(String.format(API_PLUGIN_LIST_REQUEST_FORMAT, apiEndpointUrl, appVersion, snapshotsEnabled, pluginIdQueryStr, osStr, archStr));
-		
+
 		logger.log(Level.INFO, "Querying " + pluginListUrl + " ...");
 		eventBus.post(new ConnectToHostExternalEvent(pluginListUrl.getHost()));
 


### PR DESCRIPTION
Windows currently ignores the snapshot flag during an update since it is
doing a delayed update on the basis of an external update file.

fixes syncany/syncany#418