### PR TITLE
Allow enum list for transfer settings

### DIFF
--- a/syncany-lib/src/main/java/org/syncany/plugins/local/LocalTransferSettings.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/local/LocalTransferSettings.java
@@ -35,7 +35,7 @@ import org.syncany.plugins.transfer.TransferSettings;
 public class LocalTransferSettings extends TransferSettings {
 	@Element(required = true)
 	@Setup(order = 1, fileType = FileType.FOLDER, description = "Path to local repository")
-	public File path;	
+	public File path;
 
 	public File getPath() {
 		return path;

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/TransferPluginOption.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/TransferPluginOption.java
@@ -148,7 +148,7 @@ public class TransferPluginOption {
 			return true;
 		}
 		else if (ReflectionUtil.getClassFromType(type).isEnum()) {
-			return ReflectionUtil.isValidEnum(value, ReflectionUtil.getClassFromType(type));
+			return ReflectionUtil.isValidEnum(value.toUpperCase(), ReflectionUtil.getClassFromType(type));
 		}
 		else if (type == File.class) {
 			if (isRequired()) {

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/TransferPluginOption.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/TransferPluginOption.java
@@ -21,6 +21,8 @@ import java.io.File;
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 
+import org.syncany.util.ReflectionUtil;
+
 /**
  * A plugin option represents a single setting of a transfer plugin
  * within the corresponding {@link TransferSettings} class. A plugin option
@@ -80,7 +82,7 @@ public class TransferPluginOption {
 	public Type getType() {
 		return type;
 	}
-	
+
 	public FileType getFileType() {
 		return fileType;
 	}
@@ -96,7 +98,7 @@ public class TransferPluginOption {
 	public boolean isSingular() {
 		return singular;
 	}
-	
+
 	public boolean isVisible() {
 		return visible;
 	}
@@ -144,6 +146,9 @@ public class TransferPluginOption {
 		}
 		else if (type == Boolean.TYPE) {
 			return true;
+		}
+		else if (ReflectionUtil.getClassFromType(type).isEnum()) {
+			return ReflectionUtil.isValidEnum(value, ReflectionUtil.getClassFromType(type));
 		}
 		else if (type == File.class) {
 			if (isRequired()) {

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/TransferSettings.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/TransferSettings.java
@@ -135,7 +135,7 @@ public abstract class TransferSettings {
 						field.set(this, new File(String.valueOf(value)));
 					}
 					else if (ReflectionUtil.getClassFromType(fieldType).isEnum() && value instanceof String) {
-						Enum translatedEnum = Enum.valueOf((Class<? extends Enum>) ReflectionUtil.getClassFromType(fieldType), String.valueOf(value));
+						Enum translatedEnum = Enum.valueOf((Class<? extends Enum>) ReflectionUtil.getClassFromType(fieldType), String.valueOf(value).toUpperCase());
 						field.set(this, translatedEnum);
 					}
 					else if (TransferSettings.class.isAssignableFrom(value.getClass())) {

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/TransferSettings.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/TransferSettings.java
@@ -122,7 +122,7 @@ public abstract class TransferSettings {
 					if (value == null) {
 						field.set(this, null);
 					}
-					else if (field.getType() == Integer.TYPE && (value instanceof Integer || value instanceof String)) {
+					else if (fieldType == Integer.TYPE && (value instanceof Integer || value instanceof String)) {
 						field.setInt(this, Integer.parseInt(String.valueOf(value)));
 					}
 					else if (fieldType == Boolean.TYPE && (value instanceof Boolean || value instanceof String)) {
@@ -134,6 +134,10 @@ public abstract class TransferSettings {
 					else if (fieldType == File.class && value instanceof String) {
 						field.set(this, new File(String.valueOf(value)));
 					}
+					else if (ReflectionUtil.getClassFromType(fieldType).isEnum() && value instanceof String) {
+						Enum translatedEnum = Enum.valueOf((Class<? extends Enum>) ReflectionUtil.getClassFromType(fieldType), String.valueOf(value));
+						field.set(this, translatedEnum);
+					}
 					else if (TransferSettings.class.isAssignableFrom(value.getClass())) {
 						field.set(this, ReflectionUtil.getClassFromType(fieldType).cast(value));
 					}
@@ -144,7 +148,7 @@ public abstract class TransferSettings {
 			}
 		}
 		catch (Exception e) {
-			throw new StorageException("Unable to parse value: " + e.getMessage(), e);
+			throw new StorageException("Unable to parse value because its format is invalid: " + e.getMessage(), e);
 		}
 	}
 

--- a/syncany-lib/src/test/integration/java/org/syncany/tests/integration/plugins/TransferSettingsTest.java
+++ b/syncany-lib/src/test/integration/java/org/syncany/tests/integration/plugins/TransferSettingsTest.java
@@ -41,6 +41,7 @@ import org.syncany.plugins.dummy.DummyTransferManager;
 import org.syncany.plugins.dummy.DummyTransferPlugin;
 import org.syncany.plugins.dummy.DummyTransferSettings;
 import org.syncany.plugins.local.LocalTransferSettings;
+import org.syncany.plugins.transfer.StorageException;
 import org.syncany.plugins.transfer.TransferPlugin;
 import org.syncany.plugins.transfer.TransferPluginUtil;
 import org.syncany.plugins.transfer.TransferSettings;
@@ -161,5 +162,22 @@ public class TransferSettingsTest {
 	public void testGetSettingsAndManagerFromPlugin() throws Exception {
 		Class<? extends TransferSettings> settingsClass = TransferPluginUtil.getTransferSettingsClass(DummyTransferPlugin.class);
 		assertEquals(DummyTransferSettings.class, settingsClass);
+	}
+
+	@Test
+	public void testEnumSettingValid() throws Exception {
+		final String enumValue = "A";
+
+		DummyTransferSettings testTransferSettings = new DummyTransferSettings();
+		testTransferSettings.setField("enumField", enumValue);
+		assertEquals(DummyTransferSettings.DummyEnum.A, testTransferSettings.enumField);
+	}
+
+	@Test(expected = StorageException.class)
+	public void testEnumSettingInvalid() throws Exception {
+		final String enumValue = "C"; // does not exist
+
+		DummyTransferSettings testTransferSettings = new DummyTransferSettings();
+		testTransferSettings.setField("enumField", enumValue);
 	}
 }

--- a/syncany-lib/src/test/integration/java/org/syncany/tests/integration/plugins/TransferSettingsTest.java
+++ b/syncany-lib/src/test/integration/java/org/syncany/tests/integration/plugins/TransferSettingsTest.java
@@ -171,6 +171,12 @@ public class TransferSettingsTest {
 		DummyTransferSettings testTransferSettings = new DummyTransferSettings();
 		testTransferSettings.setField("enumField", enumValue);
 		assertEquals(DummyTransferSettings.DummyEnum.A, testTransferSettings.enumField);
+
+		final String enumValueLower = "a";
+
+		testTransferSettings = new DummyTransferSettings();
+		testTransferSettings.setField("enumField", enumValueLower);
+		assertEquals(DummyTransferSettings.DummyEnum.A, testTransferSettings.enumField);
 	}
 
 	@Test(expected = StorageException.class)

--- a/syncany-lib/src/test/unit/java/org/syncany/plugins/dummy/DummyTransferSettings.java
+++ b/syncany-lib/src/test/unit/java/org/syncany/plugins/dummy/DummyTransferSettings.java
@@ -29,6 +29,10 @@ import org.syncany.plugins.transfer.TransferSettings;
  * @author Christian Roth <christian.roth@port17.de>
  */
 public class DummyTransferSettings extends TransferSettings {
+	public enum DummyEnum {
+		A, B
+	}
+
 	@Element(required = true)
 	@Encrypted
 	@Setup(order = 1, sensitive = true, description = "A foo field")
@@ -49,6 +53,10 @@ public class DummyTransferSettings extends TransferSettings {
 	@Element(name = "nest2", required = false)
 	@Setup(order = 5, description = "Some nested settings")
 	public LocalTransferSettings subsettings2;
+
+	@Element(required = false)
+	@Setup(order = 6, description = "A enum field")
+	public DummyEnum enumField;
 
 	@Validate
 	public void validate() throws StorageException {

--- a/syncany-util/src/main/java/org/syncany/util/ReflectionUtil.java
+++ b/syncany-util/src/main/java/org/syncany/util/ReflectionUtil.java
@@ -27,8 +27,8 @@ import java.util.List;
 
 /**
  * Utility class to find classes, methods and fields with certain properties -
- * typically having an annotation or a certain erasure. 
- * 
+ * typically having an annotation or a certain erasure.
+ *
  * @author Christian Roth <christian.roth@port17.de>
  */
 public abstract class ReflectionUtil {
@@ -106,5 +106,19 @@ public abstract class ReflectionUtil {
 		}
 
 		return null;
+	}
+
+	public static boolean isValidEnum(String enumValue, Class<?> enumClass) {
+		if (!enumClass.isEnum()) {
+			return false;
+		}
+
+		try {
+			Enum.valueOf((Class<? extends Enum>) enumClass, enumValue);
+			return true;
+		}
+		catch (IllegalArgumentException e) {
+			return false;
+		}
 	}
 }


### PR DESCRIPTION
Using enums allows to predefine a list of valid values for a transfer
setting option.

Should we make user inputs uppercase since it is common to have uppercased enums? At the moment, it's case sensitive:
```
- test (Valid values are: A, B): a
ERROR: Not a valid input.

- test (Valid values are: A, B): A
```

closes #280 