### PR TITLE
Do not add enums to option description

### DIFF
--- a/syncany-cli/src/main/java/org/syncany/cli/AbstractInitCommand.java
+++ b/syncany-cli/src/main/java/org/syncany/cli/AbstractInitCommand.java
@@ -494,11 +494,11 @@ public abstract class AbstractInitCommand extends Command implements UserInterac
 		String value = knownOptionValue;
 
 		if (option.isSingular() || knownOptionValue == null || "".equals(knownOptionValue)) {
-			out.printf("- %s: ", option.getDescription());
+			out.printf("- %s: ", getDescription(settings, option));
 			value = console.readLine();
 		}
 		else {
-			out.printf("- %s (%s): ", option.getDescription(), knownOptionValue);
+			out.printf("- %s (%s): ", getDescription(settings, option), knownOptionValue);
 			value = console.readLine();
 
 			if ("".equals(value)) {
@@ -520,11 +520,11 @@ public abstract class AbstractInitCommand extends Command implements UserInterac
 				defaultValueDescription = "none";
 			}
 
-			out.printf("- %s (optional, default is %s): ", option.getDescription(), defaultValueDescription);
+			out.printf("- %s (optional, default is %s): ", getDescription(settings, option), defaultValueDescription);
 			value = console.readLine();
 		}
 		else {
-			out.printf("- %s (%s): ", option.getDescription(), knownOptionValue);
+			out.printf("- %s (%s): ", getDescription(settings, option), knownOptionValue);
 			value = console.readLine();
 
 			if ("".equals(value)) {
@@ -541,11 +541,11 @@ public abstract class AbstractInitCommand extends Command implements UserInterac
 		String optionalIndicator = option.isRequired() ? "" : ", optional";
 
 		if (option.isSingular() || knownOptionValue == null || "".equals(knownOptionValue)) {
-			out.printf("- %s (not displayed%s): ", option.getDescription(), optionalIndicator);
+			out.printf("- %s (not displayed%s): ", getDescription(settings, option), optionalIndicator);
 			value = String.copyValueOf(console.readPassword());
 		}
 		else {
-			out.printf("- %s (***, not displayed%s): ", option.getDescription(), optionalIndicator);
+			out.printf("- %s (***, not displayed%s): ", getDescription(settings, option), optionalIndicator);
 			value = String.copyValueOf(console.readPassword());
 
 			if ("".equals(value)) {
@@ -554,6 +554,25 @@ public abstract class AbstractInitCommand extends Command implements UserInterac
 		}
 
 		return value;
+	}
+
+	private String getDescription(TransferSettings settings, TransferPluginOption option) {
+		Class<?> clazzForType = ReflectionUtil.getClassFromType(option.getType());
+
+		if (Enum.class.isAssignableFrom(clazzForType)) {
+			Object[] enumValues = clazzForType.getEnumConstants();
+
+			if (enumValues == null) {
+				throw new RuntimeException("Invalid TransferSettings class found: Enum at " + settings + " has no values");
+			}
+
+			logger.log(Level.FINE, "Found enum option, values are: " + StringUtil.join(enumValues, ", "));
+
+			return String.format("Choose '%s' from %s", option.getDescription(), StringUtil.join(enumValues, ", "));
+		}
+		else {
+			return option.getDescription();
+		}
 	}
 
 	protected TransferPlugin askPlugin() {

--- a/syncany-cli/src/main/java/org/syncany/cli/AbstractInitCommand.java
+++ b/syncany-cli/src/main/java/org/syncany/cli/AbstractInitCommand.java
@@ -568,7 +568,7 @@ public abstract class AbstractInitCommand extends Command implements UserInterac
 
 			logger.log(Level.FINE, "Found enum option, values are: " + StringUtil.join(enumValues, ", "));
 
-			return String.format("Choose '%s' from %s", option.getDescription(), StringUtil.join(enumValues, ", "));
+			return String.format("%s, choose from %s", option.getDescription(), StringUtil.join(enumValues, ", "));
 		}
 		else {
 			return option.getDescription();

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/TransferPluginOptions.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/TransferPluginOptions.java
@@ -19,13 +19,10 @@ package org.syncany.plugins.transfer;
 
 import java.lang.reflect.Field;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.simpleframework.xml.Element;
 import org.syncany.util.ReflectionUtil;
-import org.syncany.util.StringUtil;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
@@ -64,7 +61,7 @@ public class TransferPluginOptions {
 		return options.build();
 	}
 
-	private static TransferPluginOption getOptionFromField(Field field, Class<? extends TransferSettings> transferSettingsClass, int level) {		
+	private static TransferPluginOption getOptionFromField(Field field, Class<? extends TransferSettings> transferSettingsClass, int level) {
 		Element elementAnnotation = field.getAnnotation(Element.class);
 		Setup setupAnnotation = field.getAnnotation(Setup.class);
 
@@ -88,10 +85,10 @@ public class TransferPluginOptions {
 		boolean isNestedOption = TransferSettings.class.isAssignableFrom(field.getType());
 
 		if (isNestedOption) {
-			return createNestedOption(field, level, name, description, fileType, encrypted, sensitive, singular, visible, required, callback, converter);			
+			return createNestedOption(field, level, name, description, fileType, encrypted, sensitive, singular, visible, required, callback, converter);
 		}
 		else {
-			return createNormalOption(field, transferSettingsClass, name, description, fileType, encrypted, sensitive, singular, visible, required, callback, converter);			
+			return createNormalOption(field, transferSettingsClass, name, description, fileType, encrypted, sensitive, singular, visible, required, callback, converter);
 		}
 	}
 
@@ -99,7 +96,7 @@ public class TransferPluginOptions {
 	private static TransferPluginOption createNestedOption(Field field, int level, String name, String description, FileType fileType,
 			boolean encrypted, boolean sensitive, boolean singular, boolean visible, boolean required,
 			Class<? extends TransferPluginOptionCallback> callback, Class<? extends TransferPluginOptionConverter> converter) {
-		
+
 		if (++level > MAX_NESTED_LEVELS) {
 			throw new RuntimeException("Plugin uses too many nested transfer settings (max allowed value: " + MAX_NESTED_LEVELS + ")");
 		}
@@ -112,24 +109,8 @@ public class TransferPluginOptions {
 	private static TransferPluginOption createNormalOption(Field field, Class<? extends TransferSettings> transferSettingsClass, String name,
 			String description, FileType fileType, boolean encrypted, boolean sensitive, boolean singular, boolean visible, boolean required,
 			Class<? extends TransferPluginOptionCallback> callback, Class<? extends TransferPluginOptionConverter> converter) {
-		
-		if (Enum.class.isAssignableFrom(field.getType())) {
-			Object[] enumValues = getEnumValues(field, transferSettingsClass);			
-			description = description + " (Valid values are: " + StringUtil.join(enumValues, ", ") + ")";
-		}
 
 		return new TransferPluginOption(field, name, description, field.getType(), fileType, encrypted, sensitive, singular, visible, required, callback, converter);
-	}
-
-	private static Object[] getEnumValues(Field field, Class<? extends TransferSettings> transferSettingsClass) {
-		Object[] enumValues = field.getType().getEnumConstants();		
-		logger.log(Level.FINE, "Enum values are: " + StringUtil.join(enumValues, ", "));
-
-		if (enumValues == null) {
-			throw new RuntimeException("Invalid TransferSettings class found: Enum at " + transferSettingsClass + " has no values");
-		}
-		
-		return enumValues;
 	}
 
 	private static List<Field> getOrderedFields(Class<? extends TransferSettings> transferSettingsClass) {


### PR DESCRIPTION
because it interferes with the GUI (see syncany/syncany-plugin-s3#5)

Output:
```
$ sydev init s3
Choose a storage plugin. Available plugins are: dropbox, local, s3, sftp, webdav
Plugin: s3

Connection details for s3 connection:
- Access Key: ads
- Secret Key (not displayed): 
- Bucket: asd
- Choose 'Location' from ASIA_PACIFIC, ASIA_PACIFIC_NORTHEAST, ASIA_PACIFIC_SINGAPORE, ASIA_PACIFIC_SOUTHEAST, ASIA_PACIFIC_SYDNEY, ASIA_PACIFIC_TOKYO, EU_FRANKFURT, EU_IRELAND, EUROPE, GOVCLOUD_FIPS_US_WEST, GOVCLOUD_US_WEST, SOUTH_AMERICA_EAST, SOUTH_AMERICA_SAO_PAULO, US_WEST, US_WEST_NORTHERN_CALIFORNIA, US_WEST_OREGON, GOOGLE_US, GOOGLE_ASIA, GOOGLE_EU: 
```