### PR TITLE
Change 'sy init -t' to 'sy init -T'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ Change Log
   + Update licensing to match GPLv3+ #457
   + Prepare fix for read-after-write issue with S3 and Swift plugin #456
   + Change default crypto to just AES-128/GCM
-  + Fix table creation process to not throw an error.
+  + Fix table creation process to not throw an error
   + Fix swift read after write consistent issue #276
+  + Create target in `sy init` by default (disable with -T)
 
 ### Syncany 0.4.5-alpha (Date: 8 May 2015)
 - Developer/alpha release (**We are now nearing the beta phase. Stay tuned!**)

--- a/gradle/bash/syncany.bash-completion
+++ b/gradle/bash/syncany.bash-completion
@@ -123,7 +123,7 @@ _sy() {
 		-o --plugin-option\
 		-E --no-encryption\
 		-G --no-compression\
-		-t --create-target\
+		-T --no-create-target\
 		-a --advanced\
 		-n --add-daemon\
 		-s --short\

--- a/syncany-cli/src/main/java/org/syncany/cli/InitCommand.java
+++ b/syncany-cli/src/main/java/org/syncany/cli/InitCommand.java
@@ -87,7 +87,7 @@ public class InitCommand extends AbstractInitCommand {
 		InitOperationOptions operationOptions = new InitOperationOptions();
 
 		OptionParser parser = new OptionParser();
-		OptionSpec<Void> optionCreateTargetPath = parser.acceptsAll(asList("t", "create-target"));
+		OptionSpec<Void> optionNoCreateTarget = parser.acceptsAll(asList("T", "no-create-target"));
 		OptionSpec<Void> optionAdvanced = parser.acceptsAll(asList("a", "advanced"));
 		OptionSpec<Void> optionNoCompression = parser.acceptsAll(asList("G", "no-compression"));
 		OptionSpec<Void> optionNoEncryption = parser.acceptsAll(asList("E", "no-encryption"));
@@ -110,7 +110,7 @@ public class InitCommand extends AbstractInitCommand {
 		TransferSettings transferSettings = createTransferSettingsFromOptions(options, optionPlugin, optionPluginOpts);
 
 		// Some misc settings
-		boolean createTargetPath = options.has(optionCreateTargetPath);
+		boolean createTargetPath = !options.has(optionNoCreateTarget);
 		boolean advancedModeEnabled = options.has(optionAdvanced);
 		boolean encryptionEnabled = !options.has(optionNoEncryption);
 		boolean compressionEnabled = !options.has(optionNoCompression);

--- a/syncany-cli/src/main/java/org/syncany/cli/UpCommand.java
+++ b/syncany-cli/src/main/java/org/syncany/cli/UpCommand.java
@@ -39,7 +39,7 @@ import com.google.common.eventbus.Subscribe;
 
 public class UpCommand extends Command {
 	private int totalFileCount = -1;
-	private int uploadedFileCount = 0;
+	
 	@Override
 	public CommandScope getRequiredCommandScope() {
 		return CommandScope.INITIALIZED_LOCALDIR;

--- a/syncany-cli/src/main/resources/org/syncany/cli/cmd/help.init.skel
+++ b/syncany-cli/src/main/resources/org/syncany/cli/cmd/help.init.skel
@@ -4,7 +4,7 @@ NAME
 SYNOPSIS
   sy init [-P | --plugin=<plugin>] [-o | --plugin-option=<key=value>]
           [-E | --no-encryption] [-G | --no-compression] [-s | --short]
-          [-t | --create-target] [-a | --advanced] [-n | --add-daemon]
+          [-T | --no-create-target] [-a | --advanced] [-n | --add-daemon]
           [--password]
 
 DESCRIPTION
@@ -42,10 +42,9 @@ OPTIONS
     files are stored in uncompressed form. Can increase indexing performance,
     but will also increase transfer times and remote storage space.
 
-  -t, --create-target
-    If not existent, creates the target path on the remote storage. If this
-    option is not given, the command will fail if the target folder/path does
-    not exist.
+  -T, --no-create-target
+    Disables the creation of the target path/folder if it does not exist. If
+    this option is not given, the command will try to create the target.
 
   -a, --advanced
     Runs the interactive setup in an advanced mode, querying the user for more

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/TransferPluginOptions.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/TransferPluginOptions.java
@@ -19,10 +19,10 @@ package org.syncany.plugins.transfer;
 
 import java.lang.reflect.Field;
 import java.util.List;
-import java.util.logging.Logger;
 
 import org.simpleframework.xml.Element;
 import org.syncany.util.ReflectionUtil;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
@@ -35,7 +35,6 @@ import com.google.common.primitives.Ints;
  * @author Christian Roth <christian.roth@port17.de>
  */
 public class TransferPluginOptions {
-	private static final Logger logger = Logger.getLogger(TransferPluginOptions.class.getName());
 	private static final int MAX_NESTED_LEVELS = 3;
 
 	/**


### PR DESCRIPTION
This has annoyed me for a while. This changes the default behavior of `sy init` to create the target folder/bucket/whatever instead of failing.