### PR TITLE
Bugfix/issue534

### DIFF
--- a/gradle/wrapper/wrapper.properties
+++ b/gradle/wrapper/wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.9-bin.zip

--- a/gradle/wrapper/wrapper.properties
+++ b/gradle/wrapper/wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.9-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-bin.zip

--- a/syncany-lib/src/main/java/org/syncany/operations/restore/RestoreFileSystemAction.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/restore/RestoreFileSystemAction.java
@@ -46,10 +46,6 @@ public class RestoreFileSystemAction extends FileCreatingFileSystemAction {
 			throw new Exception("Not yet implemented.");
 		}
 		else {
-			if (fileVersion2.getStatus() == FileStatus.DELETED) {
-				throw new Exception("Cannot restore version marked DELETED. Try previous version.");
-			}
-			
 			// Assemble file to cache
 			File cacheFile = assembleFileToCache(fileVersion2);
 			

--- a/syncany-lib/src/main/java/org/syncany/operations/restore/RestoreOperation.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/restore/RestoreOperation.java
@@ -112,6 +112,9 @@ public class RestoreOperation extends AbstractTransferOperation {
 			if (fileHistory.size() >= 2) { 
 				return fileHistory.get(fileHistory.size()-2);
 			}
+			else if (fileHistory.size() == 1){
+				return fileHistory.get(0);
+			}
 			else {
 				return null;
 			}

--- a/syncany-lib/src/main/java/org/syncany/operations/restore/RestoreOperation.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/restore/RestoreOperation.java
@@ -110,9 +110,11 @@ public class RestoreOperation extends AbstractTransferOperation {
 			List<FileVersion> fileHistory = localDatabase.getFileHistory(restoreFileHistoryId);
 			
 			if (fileHistory.size() >= 2) { 
+				// In this case, we automatically restore the "previous" version
 				return fileHistory.get(fileHistory.size()-2);
 			}
 			else if (fileHistory.size() == 1){
+				// In this case, we restore the last version. This is likely a deleted version.
 				return fileHistory.get(0);
 			}
 			else {

--- a/syncany-lib/src/test/integration/java/org/syncany/tests/ScenarioTestSuite.java
+++ b/syncany-lib/src/test/integration/java/org/syncany/tests/ScenarioTestSuite.java
@@ -96,7 +96,6 @@ import org.syncany.tests.integration.scenarios.SymlinkSyncScenarioTest;
 		Issue303ScenarioTest.class,
 		Issue316ScenarioTest.class,
 		Issue374Pre1965DateScenarioTest.class,
-		Issue429ScenarioTest.class,
 		Issue520NoResumeOnCorruptXmlScenarioTest.class,
 		ManyRenamesScenarioTest.class,
 		ManySyncUpsAndDatabaseFileCleanupScenarioTest.class,

--- a/syncany-lib/src/test/integration/java/org/syncany/tests/integration/scenarios/RestoreFileScenarioTest.java
+++ b/syncany-lib/src/test/integration/java/org/syncany/tests/integration/scenarios/RestoreFileScenarioTest.java
@@ -23,11 +23,14 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.util.TreeMap;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.Test;
 import org.syncany.database.DatabaseConnectionFactory;
 import org.syncany.database.PartialFileHistory.FileHistoryId;
+import org.syncany.operations.cleanup.CleanupOperationOptions;
+import org.syncany.operations.cleanup.CleanupOperationOptions.TimeUnit;
 import org.syncany.operations.restore.RestoreOperationOptions;
 import org.syncany.plugins.transfer.TransferSettings;
 import org.syncany.tests.unit.util.TestFileUtil;
@@ -80,6 +83,57 @@ public class RestoreFileScenarioTest {
 		TestFileUtil.deleteDirectory(tempDir);
 	}
 	
+	@Test
+	public void testRestoreDeletedFileOnlyDeletedVersionRemaining() throws Exception {
+		// Setup 
+		File tempDir = TestFileUtil.createTempDirectoryInSystemTemp();
+		TransferSettings testConnection = TestConfigUtil.createTestLocalConnection();
+		TestClient clientA = new TestClient("A", testConnection);
+		java.sql.Connection databaseConnectionA = DatabaseConnectionFactory.createConnection(clientA.getDatabaseFile(), false);
+
+		// A new/up
+		clientA.createNewFile("A-original");
+		clientA.upWithForceChecksum();
+
+		String originalFileHistoryStr = TestSqlUtil.runSqlSelect("select filehistory_id from fileversion", databaseConnectionA);
+		assertNotNull(originalFileHistoryStr);
+
+		FileHistoryId originalFileHistoryId = FileHistoryId.parseFileId(originalFileHistoryStr);
+
+		// A "delete"
+		File deletedFile = new File(tempDir, "A-original-DELETED");
+		FileUtils.moveFile(clientA.getLocalFile("A-original"), deletedFile);
+
+		clientA.upWithForceChecksum();
+
+		// A "cleanup"
+
+		CleanupOperationOptions cleanupOptions = new CleanupOperationOptions();
+		TreeMap<Long, TimeUnit> purgeSettings = new TreeMap<Long, TimeUnit>();
+		purgeSettings.put(24L * 3600L, TimeUnit.DAYS);
+
+		cleanupOptions.setPurgeFileVersionSettings(purgeSettings);
+		clientA.cleanup(cleanupOptions);
+
+		// A restore
+		RestoreOperationOptions operationOptions = new RestoreOperationOptions();
+
+		operationOptions.setFileHistoryId(originalFileHistoryId);
+
+		clientA.restore(operationOptions);
+
+		assertTrue(clientA.getLocalFile("A-original (restored version 2)").exists());
+		assertEquals(
+				StringUtil.toHex(TestFileUtil.createChecksum(deletedFile)),
+				StringUtil.toHex(TestFileUtil.createChecksum(clientA.getLocalFile("A-original (restored version 2)"))));
+		assertEquals(deletedFile.lastModified(), clientA.getLocalFile("A-original (restored version 2)").lastModified());
+		assertEquals(deletedFile.length(), clientA.getLocalFile("A-original (restored version 2)").length());
+
+		// Tear down
+		clientA.deleteTestData();
+		TestFileUtil.deleteDirectory(tempDir);
+	}
+
 	@Test
 	public void testRestoreDeletedFileWithTargetFile() throws Exception {
 		// Setup 

--- a/syncany-lib/src/test/integration/java/org/syncany/tests/integration/scenarios/RestoreFileScenarioTest.java
+++ b/syncany-lib/src/test/integration/java/org/syncany/tests/integration/scenarios/RestoreFileScenarioTest.java
@@ -107,7 +107,9 @@ public class RestoreFileScenarioTest {
 		clientA.upWithForceChecksum();
 
 		// A "cleanup"
-
+		// This cleanup is meant to delete the original version and only leave the
+		// deleted version. This should result in being able to restore.
+		
 		CleanupOperationOptions cleanupOptions = new CleanupOperationOptions();
 		TreeMap<Long, TimeUnit> purgeSettings = new TreeMap<Long, TimeUnit>();
 		purgeSettings.put(24L * 3600L, TimeUnit.DAYS);


### PR DESCRIPTION
Fixes #534 by:
- Allowing the backend to restore a deleted fileversion. We simply do not throw an error where we used to.
- Allowing the frontend to detect a deleted fileversion and correctly pass the revision to the backend.

Also includes a now-functioning test.