### PR TITLE
Switching to jdk-8 and trusty build environment because jdk-7 has bugs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: java
-jdk: openjdk7
+jdk: openjdk8
+sudo: required
+dist: trusty
 
 env:
   global:
@@ -27,6 +29,8 @@ notifications:
   irc: "chat.freenode.net#syncany"
   
 before_install:
+  # Enable i386 for wine
+  - sudo dpkg --add-architecture i386
   # Update APT (necessary!)
   - sudo apt-get update
 
@@ -44,8 +48,7 @@ before_install:
   
   # Inno Setup (for Windows executable/installer)
   # Note: If this code is changed, also update syncany-plugin-gui/.travis.yml
-  - sudo add-apt-repository --yes ppa:arx/release
-  - sudo apt-get update -d
+
   - sudo apt-get install -y -q innoextract wine python-software-properties
   - wine --version 
   - innoextract --version 

--- a/build.gradle
+++ b/build.gradle
@@ -49,4 +49,7 @@ dependencies {
 	testCompile		project(path: ":syncany-lib", configuration: "tests")
 	testCompile		project(path: ":syncany-cli", configuration: "tests")
 	testCompile		project(path: ":syncany-util", configuration: "tests")
+	
+	testRuntime "org.slf4j:slf4j-log4j12:1.7.5"
+	testRuntime "log4j:log4j:1.2.7"
 }

--- a/gradle/eclipse/org.eclipse.jdt.core.prefs
+++ b/gradle/eclipse/org.eclipse.jdt.core.prefs
@@ -1,14 +1,14 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
-org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.compliance=1.8
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.7
+org.eclipse.jdt.core.compiler.source=1.8
 org.eclipse.jdt.core.formatter.align_type_members_on_columns=false
 org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression=16
 org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation=0

--- a/gradle/gradle/application.java.gradle
+++ b/gradle/gradle/application.java.gradle
@@ -5,8 +5,8 @@ subprojects {
 	
 	group = 'org.syncany'		
 		
-	sourceCompatibility = 1.7
-	targetCompatibility = 1.7
+	sourceCompatibility = 1.8
+	targetCompatibility = 1.8
 	
 	repositories {
 		mavenCentral()

--- a/gradle/gradle/development.eclipse.gradle
+++ b/gradle/gradle/development.eclipse.gradle
@@ -9,8 +9,8 @@ subprojects {
 		}
 		
 		jdt {
-			sourceCompatibility = 1.7
-			targetCompatibility = 1.7			
+			sourceCompatibility = 1.8
+			targetCompatibility = 1.8
 		}		
 	}
 	

--- a/gradle/gradle/reports.coverage.gradle
+++ b/gradle/gradle/reports.coverage.gradle
@@ -7,8 +7,8 @@ buildscript {
     }
 
     dependencies {
-        classpath 'net.saliman:gradle-cobertura-plugin:2.2.2'
-        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.3.1'
+        classpath 'net.saliman:gradle-cobertura-plugin:2.2.8'
+        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.4.0'
     }
 }
 


### PR DESCRIPTION
So. Yes.

There's one caveat here and that is that running tests through gradle doesn't work, because setting the classpath combined with -source 1.7 is not something java wants to do. I don't know what wizardry is needed to get that, so I'm pretty inclined to also move to Java 8.

@binwiederhier , opinions?