### PR TITLE
Fixed ls help: --types=<t|d|s> to --types=<f|d|s>

### DIFF
--- a/syncany-cli/src/main/resources/org/syncany/cli/cmd/help.ls.skel
+++ b/syncany-cli/src/main/resources/org/syncany/cli/cmd/help.ls.skel
@@ -33,7 +33,7 @@ OPTIONS
     Select and display the entire history of the matching files instead of only
     the last version. Useful with --group.
   
-  -t, --types=<t|d|s>            
+  -t, --types=<f|d|s>            
     Limits the result set to a certain file type ('f' for files, 'd' for
     directories, and 's' for symlinks). Types can be combined, e.g. 
     `sy ls -tfs` selects files and symlinks. Default setting is 'tds'. 


### PR DESCRIPTION
Anyway, in my opinion the best solution is to have automatic help printer like boost:program_options, or something (googled in 2 minutes: [Apache Commons CLI](http://commons.apache.org/proper/commons-cli/). I have no idea if it suits but looks promising).
Then your help for commands are written inline - so there is no place for mistakes.