### PR TITLE
Support Java 8 update 102 and later, needed because field was made fi…

### DIFF
--- a/syncany-lib/src/main/java/org/syncany/crypto/CipherUtil.java
+++ b/syncany-lib/src/main/java/org/syncany/crypto/CipherUtil.java
@@ -33,6 +33,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.RandomAccessFile;
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.math.BigInteger;
 import java.security.InvalidKeyException;
 import java.security.KeyPair;
@@ -152,11 +153,17 @@ public class CipherUtil {
 		if (!unlimitedStrengthEnabled.get()) {
 			logger.log(Level.FINE, "- Enabling unlimited strength/crypto ...");
 
+			/*
+			 * We want to turn off the isRestricted field.  However it is a
+			 * private final field.  We therefore use reflection.
+			 */
 			try {
-				Field field = Class.forName("javax.crypto.JceSecurity").getDeclaredField("isRestricted");
-
-				field.setAccessible(true);
-				field.set(null, false);
+				Field isRestrictedField = Class.forName("javax.crypto.JceSecurity").getDeclaredField("isRestricted");
+				isRestrictedField.setAccessible(true);
+				Field modifiersField = Field.class.getDeclaredField("modifiers");
+				modifiersField.setAccessible(true);
+				modifiersField.setInt(isRestrictedField, isRestrictedField.getModifiers() & ~Modifier.FINAL);
+				isRestrictedField.set(null, false);
 			}
 			catch (Exception e) {
 				throw new CipherException(e);


### PR DESCRIPTION
As Oracle changed isRestricted to final in Java 8 update 102, Syncany must now turn off the final flag before setting it to false.  Syncany is unusable with the latest Java otherwise so a release would be good.