### PR TITLE
Change pathToString to use String.replace instead of String.replaceAll

### DIFF
--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/features/PathAwareFeatureTransferManager.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/features/PathAwareFeatureTransferManager.java
@@ -272,7 +272,7 @@ public class PathAwareFeatureTransferManager implements FeatureTransferManager {
 	}
 
 	private String pathToString(Path path) {
-		return path.toString().replaceAll(File.separator, String.valueOf(folderSeparator));
+		return path.toString().replace(File.separator, String.valueOf(folderSeparator));
 	}
 
 	private boolean createFolder(RemoteFile remoteFile) throws StorageException {


### PR DESCRIPTION
This can cause problems on windows because the path separator is `\` and `String.replaceAll` won't interpret it as literal, causing exceptions to be thrown.