### PR TITLE
Avoid bash specific expressions in application.distribution.gradle.

### DIFF
--- a/gradle/gradle/application.distribution.gradle
+++ b/gradle/gradle/application.distribution.gradle
@@ -137,7 +137,7 @@ startScripts {
 		unixClassPathCommands += "for LIB_GLOBAL in \$LIBS_GLOBAL; do\n"
 		unixClassPathCommands += "	LIB_GLOBAL_BASENAME=\$(basename \$LIB_GLOBAL)\n"
 		unixClassPathCommands += "\n"
-		unixClassPathCommands += "	if [[ \$LIB_GLOBAL_BASENAME == syncany-plugin-*.jar ]]; then\n"
+		unixClassPathCommands += "	if [ \"\$LIB_GLOBAL_BASENAME\" = syncany-plugin-*.jar ]; then\n"
 		unixClassPathCommands += "		PLUGIN_JAR_PREFIX=\$(expr match \"\$LIB_GLOBAL_BASENAME\" '\\(syncany-plugin-[^-]*-\\)')\n"
 		unixClassPathCommands += "		IN_USER_PLUGINS=\$(ls \$APP_USERCONFIG_DIR/plugins/lib/\$PLUGIN_JAR_PREFIX*.jar 2> /dev/null)\n"
 		unixClassPathCommands += "\n"


### PR DESCRIPTION
Gradle's createStartScript task no longer changes the shebang to point to bash
but to the generic sh instead. However the start script uses bash specific
expressions like [[ which will cause warnings or errors with other shells.
Let's fix this by using the common [ and = expression.

This is the fix for https://github.com/syncany/syncany/issues/602