### PR TITLE
Update Syncany to work with Java 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,10 @@ gradle/arch/syncany/src
 gradle/arch/syncany/syncany*.tar*
 *.orig
 .recommenders
+
+# IntelliJ
 .idea/
 *.iml
+syncany-cli/out/
+syncany-lib/out/
+syncany-util/out/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: java
 jdk:
-  - openjdk8
   - openjdk11
 sudo: required
 dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: java
-jdk: openjdk8
+jdk:
+  - openjdk8
+  - openjdk11
 sudo: required
 dist: trusty
 

--- a/gradle/gradle/reports.coverage.gradle
+++ b/gradle/gradle/reports.coverage.gradle
@@ -13,7 +13,7 @@ subprojects {
 	apply plugin: "jacoco"
 
 	jacoco {
-		toolVersion = "0.7.6.201602180812"
+		toolVersion = "0.8.3"
 	}
 	test {
 		jacoco {

--- a/syncany-cli/build.gradle
+++ b/syncany-cli/build.gradle
@@ -1,21 +1,31 @@
 apply plugin: 'java'
 apply plugin: 'eclipse'
 
+test {
+	useJUnitPlatform()
+	testLogging {
+		events "passed", "skipped", "failed"
+	}
+}
+
 dependencies {
 	compile			project(":syncany-lib")
 	compile			project(":syncany-util")
 	compile			"net.sf.jopt-simple:jopt-simple:4.5"
 
-	// because of Java 9+
+	// Because Java 9+ does not automatically include a JAXB provider
 	// https://stackoverflow.com/questions/43574426/how-to-resolve-java-lang-noclassdeffounderror-javax-xml-bind-jaxbexception-in-j#43574427
 	// https://blog.sourced-bvba.be/article/2017/12/17/java9-spring/
-	compile			"javax.xml.bind:jaxb-api:1.0.6"
+	compile			"javax.xml.bind:jaxb-api:2.3.1"
+	compile			"org.glassfish.jaxb:jaxb-runtime:2.3.1"
 
 	testCompile		"com.github.stefanbirkner:system-rules:1.5.0"            
       	
 	testCompile		project(path: ":syncany-lib", configuration: "tests")
 	testCompile		project(path: ":syncany-util", configuration: "tests")
-	testCompile		"junit:junit:4.9"   	      
+	testCompile		"junit:junit:4.9"
+	testCompile		"org.junit.jupiter:junit-jupiter:5.4.2"
+	testRuntime		"org.junit.vintage:junit-vintage-engine:5.4.2"
 }
 
 

--- a/syncany-cli/build.gradle
+++ b/syncany-cli/build.gradle
@@ -4,8 +4,13 @@ apply plugin: 'eclipse'
 dependencies {
 	compile			project(":syncany-lib")
 	compile			project(":syncany-util")
-	compile			"net.sf.jopt-simple:jopt-simple:4.5"      
-	
+	compile			"net.sf.jopt-simple:jopt-simple:4.5"
+
+	// because of Java 9+
+	// https://stackoverflow.com/questions/43574426/how-to-resolve-java-lang-noclassdeffounderror-javax-xml-bind-jaxbexception-in-j#43574427
+	// https://blog.sourced-bvba.be/article/2017/12/17/java9-spring/
+	compile			"javax.xml.bind:jaxb-api:1.0.6"
+
 	testCompile		"com.github.stefanbirkner:system-rules:1.5.0"            
       	
 	testCompile		project(path: ":syncany-lib", configuration: "tests")

--- a/syncany-cli/src/it/java/org/syncany/tests/integration/cli/ConnectCommandWithEncryptionTest.java
+++ b/syncany-cli/src/it/java/org/syncany/tests/integration/cli/ConnectCommandWithEncryptionTest.java
@@ -88,7 +88,7 @@ public class ConnectCommandWithEncryptionTest {
 
 		// Run
 		File localDirB = TestFileUtil.createTempDirectoryInSystemTemp();
-		assertTrue(TestCliUtil.createCurrentDirectory(localDirB));
+		assertTrue(TestCliUtil.createDirectory(localDirB));
 
 		String[] connectArgs = new String[] {
 				"--localdir=" + localDirB.getAbsolutePath(),
@@ -128,7 +128,7 @@ public class ConnectCommandWithEncryptionTest {
 
 		// 2. Connect
 		File localDirB = TestFileUtil.createTempDirectoryInSystemTemp();
-		assertTrue(TestCliUtil.createCurrentDirectory(localDirB));
+		assertTrue(TestCliUtil.createDirectory(localDirB));
 
 		String[] connectArgs = new String[] {
 				"--localdir=" + localDirB.getAbsolutePath(),
@@ -185,7 +185,7 @@ public class ConnectCommandWithEncryptionTest {
 
 		initializedRepoFolder = new File(clientA.get("repopath"));
 
-		assertTrue(TestCliUtil.createCurrentDirectory(tempLocalDirA));
+		assertTrue(TestCliUtil.createDirectory(tempLocalDirA));
 
 		String[] initArgs = new String[] {
 				"--localdir=" + tempLocalDirA.getAbsolutePath(),

--- a/syncany-cli/src/it/java/org/syncany/tests/integration/cli/ConnectCommandWithEncryptionTest.java
+++ b/syncany-cli/src/it/java/org/syncany/tests/integration/cli/ConnectCommandWithEncryptionTest.java
@@ -76,7 +76,6 @@ public class ConnectCommandWithEncryptionTest {
 
 	@After
 	public void after() {
-		TestCliUtil.setCurrentDirectory(originalWorkingDirectory);
 		TestFileUtil.deleteDirectory(initializedRepoFolder);
 		TestFileUtil.deleteDirectory(initializedRepoFolderCopy);
 	}
@@ -89,9 +88,10 @@ public class ConnectCommandWithEncryptionTest {
 
 		// Run
 		File localDirB = TestFileUtil.createTempDirectoryInSystemTemp();
-		TestCliUtil.setCurrentDirectory(localDirB);
+		assertTrue(TestCliUtil.createCurrentDirectory(localDirB));
 
 		String[] connectArgs = new String[] {
+				"--localdir=" + localDirB.getAbsolutePath(),
 				"connect"
 		};
 
@@ -128,9 +128,10 @@ public class ConnectCommandWithEncryptionTest {
 
 		// 2. Connect
 		File localDirB = TestFileUtil.createTempDirectoryInSystemTemp();
-		TestCliUtil.setCurrentDirectory(localDirB);
+		assertTrue(TestCliUtil.createCurrentDirectory(localDirB));
 
 		String[] connectArgs = new String[] {
+				"--localdir=" + localDirB.getAbsolutePath(),
 				"connect",
 				initializedRepoConnectLink
 		};
@@ -184,9 +185,10 @@ public class ConnectCommandWithEncryptionTest {
 
 		initializedRepoFolder = new File(clientA.get("repopath"));
 
-		TestCliUtil.setCurrentDirectory(tempLocalDirA);
+		assertTrue(TestCliUtil.createCurrentDirectory(tempLocalDirA));
 
 		String[] initArgs = new String[] {
+				"--localdir=" + tempLocalDirA.getAbsolutePath(),
 				"init"
 		};
 

--- a/syncany-cli/src/it/java/org/syncany/tests/integration/cli/InitAndConnectCommandNoEncryptionTest.java
+++ b/syncany-cli/src/it/java/org/syncany/tests/integration/cli/InitAndConnectCommandNoEncryptionTest.java
@@ -46,22 +46,18 @@ public class InitAndConnectCommandNoEncryptionTest {
 		originalWorkingDirectory = new File(System.getProperty("user.dir"));
 	}
 
-	@After
-	public void after() {
-		TestCliUtil.setCurrentDirectory(originalWorkingDirectory);
-	}
-
 	@Test
 	public void testCliInitCommandUninitializedLocalDir() throws Exception {
 		// Setup
 		File tempDir = TestFileUtil.createTempDirectoryInSystemTemp();
-		TestCliUtil.setCurrentDirectory(tempDir);
+		assertTrue(TestCliUtil.createCurrentDirectory(tempDir));
 
 		Map<String, String> connectionSettings = TestConfigUtil.createTestLocalConnectionSettings();
 		Map<String, String> clientA = TestCliUtil.createLocalTestEnv("A", connectionSettings);
 
 		// Run
 		String[] initArgs = new String[] {
+				"--localdir=" + tempDir.getAbsolutePath(),
 				"init",
 				"--plugin", "local",
 				"--plugin-option", "path=" + clientA.get("repopath"),
@@ -77,8 +73,6 @@ public class InitAndConnectCommandNoEncryptionTest {
 		assertTrue(new File(tempDir + "/.syncany/config.xml").exists());
 
 		// Tear down
-		TestCliUtil.setCurrentDirectory(originalWorkingDirectory);
-
 		TestCliUtil.deleteTestLocalConfigAndData(clientA);
 		TestFileUtil.deleteDirectory(tempDir);
 	}
@@ -87,7 +81,7 @@ public class InitAndConnectCommandNoEncryptionTest {
 	public void testCliInitCommandInteractive() throws Exception {
 		// Setup
 		File tempDir = TestFileUtil.createTempDirectoryInSystemTemp();
-		TestCliUtil.setCurrentDirectory(tempDir);
+		assertTrue(TestCliUtil.createCurrentDirectory(tempDir));
 
 		// Ensuring no console is set
 		InitConsole.setInstance(null);
@@ -97,6 +91,7 @@ public class InitAndConnectCommandNoEncryptionTest {
 
 		// Run
 		String[] initArgs = new String[] {
+				"--localdir=" + tempDir.getAbsolutePath(),
 				"init",
 				"--no-encryption",
 				"--no-compression"
@@ -115,8 +110,6 @@ public class InitAndConnectCommandNoEncryptionTest {
 		assertTrue(new File(tempDir + "/.syncany/config.xml").exists());
 
 		// Tear down
-		TestCliUtil.setCurrentDirectory(originalWorkingDirectory);
-
 		TestCliUtil.deleteTestLocalConfigAndData(clientA);
 		TestFileUtil.deleteDirectory(tempDir);
 	}

--- a/syncany-cli/src/it/java/org/syncany/tests/integration/cli/InitAndConnectCommandNoEncryptionTest.java
+++ b/syncany-cli/src/it/java/org/syncany/tests/integration/cli/InitAndConnectCommandNoEncryptionTest.java
@@ -23,7 +23,6 @@ import static org.junit.contrib.java.lang.system.TextFromStandardInputStream.emp
 import java.io.File;
 import java.util.Map;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -50,7 +49,7 @@ public class InitAndConnectCommandNoEncryptionTest {
 	public void testCliInitCommandUninitializedLocalDir() throws Exception {
 		// Setup
 		File tempDir = TestFileUtil.createTempDirectoryInSystemTemp();
-		assertTrue(TestCliUtil.createCurrentDirectory(tempDir));
+		assertTrue(TestCliUtil.createDirectory(tempDir));
 
 		Map<String, String> connectionSettings = TestConfigUtil.createTestLocalConnectionSettings();
 		Map<String, String> clientA = TestCliUtil.createLocalTestEnv("A", connectionSettings);
@@ -81,7 +80,7 @@ public class InitAndConnectCommandNoEncryptionTest {
 	public void testCliInitCommandInteractive() throws Exception {
 		// Setup
 		File tempDir = TestFileUtil.createTempDirectoryInSystemTemp();
-		assertTrue(TestCliUtil.createCurrentDirectory(tempDir));
+		assertTrue(TestCliUtil.createDirectory(tempDir));
 
 		// Ensuring no console is set
 		InitConsole.setInstance(null);

--- a/syncany-cli/src/it/java/org/syncany/tests/integration/cli/LsRemoteCommandTest.java
+++ b/syncany-cli/src/it/java/org/syncany/tests/integration/cli/LsRemoteCommandTest.java
@@ -20,7 +20,9 @@ package org.syncany.tests.integration.cli;
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.junit.Test;
 import org.syncany.cli.CommandLineClient;
@@ -41,7 +43,7 @@ public class LsRemoteCommandTest {
 				"ls-remote"
 		}));
 
-		assertEquals("Different number of output lines expected.", 3, cliOut.length);
+		assertEquals("Different number of output lines expected.\n" + String.join("\n", cliOut), 3, cliOut.length);
 
 		// Round 2: One new database expected
 		TestFileUtil.createRandomFile(new File(clientB.get("localdir") + "/file1"), 20 * 1024);

--- a/syncany-cli/src/it/java/org/syncany/tests/integration/cli/LsRemoteCommandTest.java
+++ b/syncany-cli/src/it/java/org/syncany/tests/integration/cli/LsRemoteCommandTest.java
@@ -17,18 +17,16 @@
  */
 package org.syncany.tests.integration.cli;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.File;
-import java.util.Arrays;
-import java.util.Map;
-import java.util.stream.Collectors;
-
 import org.junit.Test;
 import org.syncany.cli.CommandLineClient;
 import org.syncany.tests.util.TestCliUtil;
-import org.syncany.tests.util.TestFileUtil;
 import org.syncany.tests.util.TestConfigUtil;
+import org.syncany.tests.util.TestFileUtil;
+
+import java.io.File;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
 
 public class LsRemoteCommandTest {
 	@Test

--- a/syncany-cli/src/test/java/org/syncany/tests/util/TestCliUtil.java
+++ b/syncany-cli/src/test/java/org/syncany/tests/util/TestCliUtil.java
@@ -135,14 +135,8 @@ public class TestCliUtil {
 		return toString(bos).split("[\\r\\n]|[\\n\\r]|[\\n]");
 	}
 
-	public static boolean setCurrentDirectory(File newDirectory) {
-		boolean result = false;
+	public static boolean createCurrentDirectory(File newDirectory) {
 		File directory = newDirectory.getAbsoluteFile();
-
-		if (directory.exists() || directory.mkdirs()) {
-			result = (System.setProperty("user.dir", directory.getAbsolutePath()) != null);
-		}
-
-		return result;
+		return directory.exists() || directory.mkdirs();
 	}
 }

--- a/syncany-cli/src/test/java/org/syncany/tests/util/TestCliUtil.java
+++ b/syncany-cli/src/test/java/org/syncany/tests/util/TestCliUtil.java
@@ -135,7 +135,7 @@ public class TestCliUtil {
 		return toString(bos).split("[\\r\\n]|[\\n\\r]|[\\n]");
 	}
 
-	public static boolean createCurrentDirectory(File newDirectory) {
+	public static boolean createDirectory(File newDirectory) {
 		File directory = newDirectory.getAbsoluteFile();
 		return directory.exists() || directory.mkdirs();
 	}

--- a/syncany-lib/build.gradle
+++ b/syncany-lib/build.gradle
@@ -9,6 +9,13 @@ repositories {
 	mavenCentral()
 }
 
+test {
+	useJUnitPlatform()
+	testLogging {
+		events "passed", "skipped", "failed"
+	}
+}
+
 dependencies {
 	compile			project(':syncany-util')
 
@@ -16,7 +23,7 @@ dependencies {
 	compile			"org.bouncycastle:bcprov-jdk15on:1.51"
 	compile			"org.bouncycastle:bcpkix-jdk15on:1.51"
 	compile			"org.simpleframework:simple-xml:2.7.1"
-	compile			"com.google.guava:guava:15.0"
+	compile			"com.google.guava:guava:27.1-jre"
 	compile			"commons-codec:commons-codec:1.8"
 	compile			"org.hsqldb:hsqldb:2.3.1"
 	compile			"com.github.zafarkhaja:java-semver:0.7.2"
@@ -29,6 +36,8 @@ dependencies {
 	testCompile		project(path: ':syncany-util', configuration: 'tests')
 	testCompile		"org.mockito:mockito-all:1.10.19"
 	testCompile		"junit:junit:4.9"
+	testCompile		"org.junit.jupiter:junit-jupiter:5.4.2"
+	testRuntime		"org.junit.vintage:junit-vintage-engine:5.4.2"
 	testCompile		"net.sourceforge.htmlunit:htmlunit:2.15"
 }
 

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/TransferSettings.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/TransferSettings.java
@@ -27,6 +27,7 @@ import java.lang.reflect.Type;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.google.common.base.MoreObjects;
 import org.apache.commons.io.IOUtils;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
@@ -39,8 +40,6 @@ import org.syncany.plugins.Plugin;
 import org.syncany.plugins.UserInteractionListener;
 import org.syncany.util.ReflectionUtil;
 import org.syncany.util.StringUtil;
-
-import com.google.common.base.Objects;
 
 /**
  * A connection represents the configuration settings of a storage/connection
@@ -238,7 +237,7 @@ public abstract class TransferSettings {
 
 	@Override
 	public String toString() {
-		Objects.ToStringHelper toStringHelper = Objects.toStringHelper(this);
+		MoreObjects.ToStringHelper toStringHelper = MoreObjects.toStringHelper(this);
 
 		for (Field field : ReflectionUtil.getAllFieldsWithAnnotation(this.getClass(), Element.class)) {
 			field.setAccessible(true);

--- a/syncany-util/build.gradle
+++ b/syncany-util/build.gradle
@@ -11,7 +11,12 @@ repositories {
 dependencies {
 	compile			"commons-io:commons-io:2.4"
 	compile			"org.hsqldb:hsqldb:2.3.1"
-	            	
+
+	// because of Java 9+
+	// https://stackoverflow.com/questions/43574426/how-to-resolve-java-lang-noclassdeffounderror-javax-xml-bind-jaxbexception-in-j#43574427
+	// https://blog.sourced-bvba.be/article/2017/12/17/java9-spring/
+	compile			"javax.xml.bind:jaxb-api:1.0.6"
+
 	testCompile		"junit:junit:4.9"   	      
 }
 

--- a/syncany-util/build.gradle
+++ b/syncany-util/build.gradle
@@ -8,16 +8,26 @@ repositories {
 	mavenCentral()
 }
 
+test {
+	useJUnitPlatform()
+	testLogging {
+		events "passed", "skipped", "failed"
+	}
+}
+
 dependencies {
 	compile			"commons-io:commons-io:2.4"
 	compile			"org.hsqldb:hsqldb:2.3.1"
 
-	// because of Java 9+
+	// Because Java 9+ does not automatically include a JAXB provider
 	// https://stackoverflow.com/questions/43574426/how-to-resolve-java-lang-noclassdeffounderror-javax-xml-bind-jaxbexception-in-j#43574427
 	// https://blog.sourced-bvba.be/article/2017/12/17/java9-spring/
-	compile			"javax.xml.bind:jaxb-api:1.0.6"
+	compile			"javax.xml.bind:jaxb-api:2.3.1"
+	compile			"org.glassfish.jaxb:jaxb-runtime:2.3.1"
 
-	testCompile		"junit:junit:4.9"   	      
+	testCompile		"junit:junit:4.9"
+	testCompile		"org.junit.jupiter:junit-jupiter:5.4.2"
+	testRuntime		"org.junit.vintage:junit-vintage-engine:5.4.2"
 }
 
 


### PR DESCRIPTION
Currently, the Syncany codebase does not compile when using Java 11.  This PR makes the necessary changes to allow compiling and running Syncany on a system that uses Java 11.