### PR TITLE
Switch to default doclet.

### DIFF
--- a/gradle/gradle/reports.javadoc.gradle
+++ b/gradle/gradle/reports.javadoc.gradle
@@ -1,23 +1,3 @@
-// JavaDoc Requirements ////////////////////////////////////////////////////////
-
-configurations {
-	doclet 
-}
-
-allprojects {
-	configurations {
-		doclet
-	}
-	
-	dependencies {
-		doclet group: 'org.jboss.apiviz', name: 'apiviz', version: '1.3.2.GA'
-	}
-	
-	repositories {
-		mavenCentral()
-	}
-}
-
 // JavaDoc /////////////////////////////////////////////////////////////////////
 
 task javadocAll(type: Javadoc) {
@@ -33,18 +13,16 @@ task javadocAll(type: Javadoc) {
 	}
 	
 	options.linkSource = true
-        options.addStringOption('sourceclasspath', files(subprojects.collect { project -> project.sourceSets.main.output }).getAsPath())
+	options.addStringOption('sourcepath', files(subprojects.collect { project -> project.sourceSets.main.output }).getAsPath())
 
 	configure(options) {
-	        doclet "org.jboss.apiviz.APIviz"
-	        docletpath file(configurations.doclet.asPath)
 		windowTitle = 'Syncany API Documentation'
 		docTitle = "Syncany JavaDoc ($applicationVersion)"
 		bottom = " \
-			<span style=\"font-size: 13px\"><br /> \
-				<a href=\"http://www.syncany.org/\" target=\"_top\">Syncany</a> is an open-source cloud storage and filesharing application.<br /><br /> \
-				Code located at <a href=\"https://github.com/syncany/syncany\" target=\"_top\">https://github.com/syncany/syncany</a><br /> \
-				JavaDoc for version $applicationVersion generated based on commit <a href=\"https://github.com/syncany/syncany/tree/$applicationRevision\" target=\"_top\">$applicationRevision</a> at $applicationDate<br /><br /> \
+			<span style=\"font-size: 13px\"><br> \
+				<a href=\"http://www.syncany.org/\" target=\"_top\">Syncany</a> is an open-source cloud storage and filesharing application.<br><br> \
+				Code located at <a href=\"https://github.com/syncany/syncany\" target=\"_top\">https://github.com/syncany/syncany</a><br> \
+				JavaDoc for version $applicationVersion generated based on commit <a href=\"https://github.com/syncany/syncany/tree/$applicationRevision\" target=\"_top\">$applicationRevision</a> at $applicationDate<br><br> \
 				Copyright &copy; 2011-2015 <a href=\"http://www.philippheckel.com/\" target=\"_top\">Philipp C. Heckel</a> \
 			</span> \
 		"

--- a/syncany-cli/src/main/java/org/syncany/Syncany.java
+++ b/syncany-cli/src/main/java/org/syncany/Syncany.java
@@ -45,7 +45,7 @@ import org.syncany.cli.CommandLineClient;
  * 
  * @see <a href="https://www.syncany.org/">Syncany website</a>
  * @see <a href="https://github.com/syncany/syncany">GitHub code repository</a> 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class Syncany {
 	public static void main(String[] args) throws Exception {

--- a/syncany-cli/src/main/java/org/syncany/cli/AbstractInitCommand.java
+++ b/syncany-cli/src/main/java/org/syncany/cli/AbstractInitCommand.java
@@ -72,8 +72,8 @@ import com.google.common.eventbus.Subscribe;
  * and 'connect' command. Both commands must provide the ability to
  * query a user for transfer settings or parse settings from the command line
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
+ * @author Christian Roth (christian.roth@port17.de)
  */
 public abstract class AbstractInitCommand extends Command implements UserInteractionListener {
 	private static final Logger logger = Logger.getLogger(AbstractInitCommand.class.getName());
@@ -333,7 +333,7 @@ public abstract class AbstractInitCommand extends Command implements UserInterac
 	 * asks for all of the plugin's settings.
 	 *
 	 * <p>This case is triggered by a field looking like this:
-	 * <tt>private TransferSettings childPluginSettings;</tt>
+	 * <code>private TransferSettings childPluginSettings;</code>
 	 */
 	private void askGenericChildPluginSettings(TransferSettings settings, TransferPluginOption option, Map<String, String> knownPluginSettings,
 			String nestPrefix)
@@ -391,7 +391,7 @@ public abstract class AbstractInitCommand extends Command implements UserInterac
 	 * Asks the user for all of the child plugin's settings.
 	 *
 	 * <p>This case is triggered by a field looking like this:
-	 * <tt>private LocalTransferSettings localChildPluginSettings;</tt>
+	 * <code>private LocalTransferSettings localChildPluginSettings;</code>
 	 */
 	private void askConreteChildPluginSettings(TransferSettings settings, NestedTransferPluginOption option, Map<String, String> knownPluginSettings,
 			String nestPrefix) throws StorageException, IllegalAccessException, InstantiationException, IllegalArgumentException,

--- a/syncany-cli/src/main/java/org/syncany/cli/Command.java
+++ b/syncany-cli/src/main/java/org/syncany/cli/Command.java
@@ -42,9 +42,9 @@ import org.syncany.operations.OperationResult;
  * 
  * <p>Commands are automatically mapped from their camel case name on the command line
  * to a class name using the {@link CommandFactory}. The command 'ls-remote', for instance,
- * is mapped to the <tt>LsRemoteCommand</tt>.
+ * is mapped to the <code>LsRemoteCommand</code>.
  *  
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public abstract class Command {
 	protected Config config;

--- a/syncany-cli/src/main/java/org/syncany/cli/CommandFactory.java
+++ b/syncany-cli/src/main/java/org/syncany/cli/CommandFactory.java
@@ -28,7 +28,7 @@ import org.syncany.util.StringUtil;
  * and run commands by mapping a command argument to a corresponding
  * {@link Command} class.
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class CommandFactory {
 	private static final Logger logger = Logger.getLogger(CommandFactory.class.getSimpleName());
@@ -38,10 +38,10 @@ public class CommandFactory {
 	 * instantiates it. The command name is camel-cased and mapped to a FQCN.
 	 * 
 	 * <p>Example: The command 'ls-remote' is mapped to the FQCN
-	 * <tt>org.syncany.cli.LsRemoteCommand</tt>.
+	 * <code>org.syncany.cli.LsRemoteCommand</code>.
 	 * 
 	 * @param commandName Command name, e.g. ls-remote or init
-	 * @return Returns a <tt>Command</tt> instance, or <tt>null</tt> if the command name cannot be mapped to a class
+	 * @return Returns a <code>Command</code> instance, or <code>null</code> if the command name cannot be mapped to a class
 	 */
 	public static Command getInstance(String commandName) {
 		String thisPackage = CommandFactory.class.getPackage().getName();

--- a/syncany-cli/src/main/java/org/syncany/cli/CommandLineClient.java
+++ b/syncany-cli/src/main/java/org/syncany/cli/CommandLineClient.java
@@ -86,7 +86,7 @@ import org.syncany.util.StringUtil;
  * commands. It furthermore detects if a local folder is handled by the daemon and, if so,
  * passes the command to the daemon via REST.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class CommandLineClient extends Client {
 	private static final Logger logger = Logger.getLogger(CommandLineClient.class.getSimpleName());

--- a/syncany-cli/src/main/java/org/syncany/cli/CommandScope.java
+++ b/syncany-cli/src/main/java/org/syncany/cli/CommandScope.java
@@ -22,7 +22,7 @@ package org.syncany.cli;
  * scope. Repository-initializing commands such as 'init' or 'connect' must be
  * run outside a repo dir.
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public enum CommandScope {
 	/**

--- a/syncany-cli/src/main/java/org/syncany/cli/DebugCommand.java
+++ b/syncany-cli/src/main/java/org/syncany/cli/DebugCommand.java
@@ -35,7 +35,7 @@ import org.syncany.operations.OperationResult;
  * Intentionally undocumented command to help debugging the application. Implements various
  * helpers for the repository and the local directory.
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class DebugCommand extends Command {
 	private static final Logger logger = Logger.getLogger(DebugCommand.class.getSimpleName());

--- a/syncany-lib/src/it/java/org/syncany/tests/integration/database/DatabaseReconciliatorTest.java
+++ b/syncany-lib/src/it/java/org/syncany/tests/integration/database/DatabaseReconciliatorTest.java
@@ -505,7 +505,7 @@ public class DatabaseReconciliatorTest {
 	@Test
 	public void testTwoWinningVersionsWithSameTimestamp() throws Exception {
 		/* Scenario: Three clients, to conflicting DBVs with the same timestamp
-		 *           --> A should win over B (alphabetical order)
+		 *           --&gt; A should win over B (alphabetical order)
 		 */
 		Logging.init();
 

--- a/syncany-lib/src/it/java/org/syncany/tests/integration/database/DatabaseReconciliatorTest.java
+++ b/syncany-lib/src/it/java/org/syncany/tests/integration/database/DatabaseReconciliatorTest.java
@@ -505,7 +505,7 @@ public class DatabaseReconciliatorTest {
 	@Test
 	public void testTwoWinningVersionsWithSameTimestamp() throws Exception {
 		/* Scenario: Three clients, to conflicting DBVs with the same timestamp
-		 *           --&gt; A should win over B (alphabetical order)
+		 *           --> A should win over B (alphabetical order)
 		 */
 		Logging.init();
 

--- a/syncany-lib/src/it/java/org/syncany/tests/integration/plugins/OAuthTokenWebListenerTest.java
+++ b/syncany-lib/src/it/java/org/syncany/tests/integration/plugins/OAuthTokenWebListenerTest.java
@@ -26,7 +26,7 @@ import com.gargoylesoftware.htmlunit.WebClient;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 
 /**
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Christian Roth (christian.roth@port17.de)
  */
 
 public class OAuthTokenWebListenerTest {

--- a/syncany-lib/src/it/java/org/syncany/tests/integration/plugins/local/LocalTransferManagerPluginTest.java
+++ b/syncany-lib/src/it/java/org/syncany/tests/integration/plugins/local/LocalTransferManagerPluginTest.java
@@ -25,7 +25,7 @@ import org.syncany.tests.integration.plugins.AbstractTransferManagerTest;
 import org.syncany.tests.util.TestFileUtil;
 
 /**
- * @author Vincent Wiencek <vwiencek@gmail.com>
+ * @author Vincent Wiencek (vwiencek@gmail.com)
  */
 public class LocalTransferManagerPluginTest extends AbstractTransferManagerTest {
 	private File tempRepoPath;

--- a/syncany-lib/src/it/java/org/syncany/tests/integration/scenarios/FileVanishedScenarioTest.java
+++ b/syncany-lib/src/it/java/org/syncany/tests/integration/scenarios/FileVanishedScenarioTest.java
@@ -102,7 +102,7 @@ public class FileVanishedScenarioTest {
 		clientB.status();
 
 		// Delete files and run up simultaneously
-		// --> This will hopefully lead to a couple of 'vanished' files
+		// --&gt; This will hopefully lead to a couple of 'vanished' files
 		logger.log(Level.INFO, "Starting 'up' thread ...");
 		runUpThread.start();
 

--- a/syncany-lib/src/it/java/org/syncany/tests/integration/scenarios/FileVanishedScenarioTest.java
+++ b/syncany-lib/src/it/java/org/syncany/tests/integration/scenarios/FileVanishedScenarioTest.java
@@ -102,7 +102,7 @@ public class FileVanishedScenarioTest {
 		clientB.status();
 
 		// Delete files and run up simultaneously
-		// --&gt; This will hopefully lead to a couple of 'vanished' files
+		// --> This will hopefully lead to a couple of 'vanished' files
 		logger.log(Level.INFO, "Starting 'up' thread ...");
 		runUpThread.start();
 

--- a/syncany-lib/src/it/java/org/syncany/tests/integration/scenarios/FilenameCapitalizationWindowsScenarioTest.java
+++ b/syncany-lib/src/it/java/org/syncany/tests/integration/scenarios/FilenameCapitalizationWindowsScenarioTest.java
@@ -27,7 +27,7 @@ import static org.syncany.tests.util.TestAssertUtil.assertFileListEquals;
 import static org.syncany.tests.util.TestAssertUtil.assertSqlDatabaseEquals;
 
 public class FilenameCapitalizationWindowsScenarioTest {
-	// TODO [medium] Windows: LARGE/small capitalization --> Dropbox makes a file "name (Case Conflict 1)"; define expected/desired behavior
+	// TODO [medium] Windows: LARGE/small capitalization --&gt; Dropbox makes a file "name (Case Conflict 1)"; define expected/desired behavior
 
 	@Test
 	public void testFilenameCapitalizationWindows() throws Exception {

--- a/syncany-lib/src/it/java/org/syncany/tests/integration/scenarios/FilenameCapitalizationWindowsScenarioTest.java
+++ b/syncany-lib/src/it/java/org/syncany/tests/integration/scenarios/FilenameCapitalizationWindowsScenarioTest.java
@@ -27,7 +27,7 @@ import static org.syncany.tests.util.TestAssertUtil.assertFileListEquals;
 import static org.syncany.tests.util.TestAssertUtil.assertSqlDatabaseEquals;
 
 public class FilenameCapitalizationWindowsScenarioTest {
-	// TODO [medium] Windows: LARGE/small capitalization --&gt; Dropbox makes a file "name (Case Conflict 1)"; define expected/desired behavior
+	// TODO [medium] Windows: LARGE/small capitalization --> Dropbox makes a file "name (Case Conflict 1)"; define expected/desired behavior
 
 	@Test
 	public void testFilenameCapitalizationWindows() throws Exception {

--- a/syncany-lib/src/it/java/org/syncany/tests/integration/scenarios/MixedUpDownScenarioTest.java
+++ b/syncany-lib/src/it/java/org/syncany/tests/integration/scenarios/MixedUpDownScenarioTest.java
@@ -144,9 +144,9 @@ import org.syncany.tests.util.TestConfigUtil;
  *                                            
  *  - Result:
  *     Winner: (A3,  ,C4)/T=10 
- *     --> Conflicts with local version
- *     --> Local must merge local version (  ,B1,C3) in (A3,  ,C4)
- *     --> Local result is then (A3,B2,C4)		  
+ *     --&gt; Conflicts with local version
+ *     --&gt; Local must merge local version (  ,B1,C3) in (A3,  ,C4)
+ *     --&gt; Local result is then (A3,B2,C4)
  *     
  * CONFLICT 2 at A: 
  *  - Local:     (  ,  ,C1)/T=01
@@ -174,7 +174,7 @@ import org.syncany.tests.util.TestConfigUtil;
  *                                            
  *  - Result:
  *     Winner: (A3,  ,C4)/T=10 
- *     --> That's me. Do nothing.     
+ *     --&gt; That's me. Do nothing.
  *     
  * CONFLICT 3 at C: 
  *  - Local:     (  ,  ,C1)/T=01
@@ -211,7 +211,7 @@ import org.syncany.tests.util.TestConfigUtil;
  *                                            
  *  - Result:
  *     Winner: (A3,  ,C4)/T=10 
- *     --> That's not me. Must apply changes locally.     
+ *     --&gt; That's not me. Must apply changes locally.
  *     
  * CONFLICT 4 at B: 
  *  - Local:     (  ,  ,C1)/T=01
@@ -248,9 +248,9 @@ import org.syncany.tests.util.TestConfigUtil;
  *                                            
  *  - Result:
  *     Winner: (A6,  ,C4)/T=19 
- *     --> Conflicts with local version
- *     --> Local must merge local version (A3,B5,C4) in (A6,  ,C4)
- *     --> Local result is then (A6,B6,C4)	         
+ *     --&gt; Conflicts with local version
+ *     --&gt; Local must merge local version (A3,B5,C4) in (A6,  ,C4)
+ *     --&gt; Local result is then (A6,B6,C4)
  *     
  * CONFLICT 5 at A: 
  *  - Local:     (  ,  ,C1)/T=01
@@ -287,7 +287,7 @@ import org.syncany.tests.util.TestConfigUtil;
  *                                            
  *  - Result:
  *     Winner: (A6,  ,C4)/T=19 
- *     --> That's me. Do nothing.           
+ *     --&gt; That's me. Do nothing.
  *     
  * CONFLICT 6 at C: 
  *  - Local:     (  ,  ,C1)/T=01
@@ -324,9 +324,9 @@ import org.syncany.tests.util.TestConfigUtil;
  *                                            
  *  - Result:
  *     Winner: (A6,  ,C4)/T=19 
- *     --> Conflicts with local version
- *     --> Local must merge local version (A3,  ,C8) in (A6,  ,C4)
- *     --> Local result is then (A6,  ,C9)	        
+ *     --&gt; Conflicts with local version
+ *     --&gt; Local must merge local version (A3,  ,C8) in (A6,  ,C4)
+ *     --&gt; Local result is then (A6,  ,C9)
  *     
  * CONFLICT 7 at C: 
  *  - Local:     (  ,  ,C1)/T=01
@@ -368,9 +368,9 @@ import org.syncany.tests.util.TestConfigUtil;
  *                                            
  *  - Result:
  *     Winner: (A6,  ,C4)/T=19 
- *     --> Conflicts with local version
- *     --> Local must merge local version (A3,  ,C8) in (A6,  ,C4)
- *     --> Local result is then (A6,  ,C9)	        
+ *     --&gt; Conflicts with local version
+ *     --&gt; Local must merge local version (A3,  ,C8) in (A6,  ,C4)
+ *     --&gt; Local result is then (A6,  ,C9)
  */		
 public class MixedUpDownScenarioTest {
 	@Test

--- a/syncany-lib/src/it/java/org/syncany/tests/integration/scenarios/MixedUpDownScenarioTest.java
+++ b/syncany-lib/src/it/java/org/syncany/tests/integration/scenarios/MixedUpDownScenarioTest.java
@@ -144,9 +144,9 @@ import org.syncany.tests.util.TestConfigUtil;
  *                                            
  *  - Result:
  *     Winner: (A3,  ,C4)/T=10 
- *     --&gt; Conflicts with local version
- *     --&gt; Local must merge local version (  ,B1,C3) in (A3,  ,C4)
- *     --&gt; Local result is then (A3,B2,C4)
+ *     --> Conflicts with local version
+ *     --> Local must merge local version (  ,B1,C3) in (A3,  ,C4)
+ *     --> Local result is then (A3,B2,C4)
  *     
  * CONFLICT 2 at A: 
  *  - Local:     (  ,  ,C1)/T=01
@@ -174,7 +174,7 @@ import org.syncany.tests.util.TestConfigUtil;
  *                                            
  *  - Result:
  *     Winner: (A3,  ,C4)/T=10 
- *     --&gt; That's me. Do nothing.
+ *     --> That's me. Do nothing.
  *     
  * CONFLICT 3 at C: 
  *  - Local:     (  ,  ,C1)/T=01
@@ -211,7 +211,7 @@ import org.syncany.tests.util.TestConfigUtil;
  *                                            
  *  - Result:
  *     Winner: (A3,  ,C4)/T=10 
- *     --&gt; That's not me. Must apply changes locally.
+ *     --> That's not me. Must apply changes locally.
  *     
  * CONFLICT 4 at B: 
  *  - Local:     (  ,  ,C1)/T=01
@@ -248,9 +248,9 @@ import org.syncany.tests.util.TestConfigUtil;
  *                                            
  *  - Result:
  *     Winner: (A6,  ,C4)/T=19 
- *     --&gt; Conflicts with local version
- *     --&gt; Local must merge local version (A3,B5,C4) in (A6,  ,C4)
- *     --&gt; Local result is then (A6,B6,C4)
+ *     --> Conflicts with local version
+ *     --> Local must merge local version (A3,B5,C4) in (A6,  ,C4)
+ *     --> Local result is then (A6,B6,C4)
  *     
  * CONFLICT 5 at A: 
  *  - Local:     (  ,  ,C1)/T=01
@@ -287,7 +287,7 @@ import org.syncany.tests.util.TestConfigUtil;
  *                                            
  *  - Result:
  *     Winner: (A6,  ,C4)/T=19 
- *     --&gt; That's me. Do nothing.
+ *     --> That's me. Do nothing.
  *     
  * CONFLICT 6 at C: 
  *  - Local:     (  ,  ,C1)/T=01
@@ -324,9 +324,9 @@ import org.syncany.tests.util.TestConfigUtil;
  *                                            
  *  - Result:
  *     Winner: (A6,  ,C4)/T=19 
- *     --&gt; Conflicts with local version
- *     --&gt; Local must merge local version (A3,  ,C8) in (A6,  ,C4)
- *     --&gt; Local result is then (A6,  ,C9)
+ *     --> Conflicts with local version
+ *     --> Local must merge local version (A3,  ,C8) in (A6,  ,C4)
+ *     --> Local result is then (A6,  ,C9)
  *     
  * CONFLICT 7 at C: 
  *  - Local:     (  ,  ,C1)/T=01
@@ -368,9 +368,9 @@ import org.syncany.tests.util.TestConfigUtil;
  *                                            
  *  - Result:
  *     Winner: (A6,  ,C4)/T=19 
- *     --&gt; Conflicts with local version
- *     --&gt; Local must merge local version (A3,  ,C8) in (A6,  ,C4)
- *     --&gt; Local result is then (A6,  ,C9)
+ *     --> Conflicts with local version
+ *     --> Local must merge local version (A3,  ,C8) in (A6,  ,C4)
+ *     --> Local result is then (A6,  ,C9)
  */		
 public class MixedUpDownScenarioTest {
 	@Test

--- a/syncany-lib/src/main/java/org/syncany/Client.java
+++ b/syncany-lib/src/main/java/org/syncany/Client.java
@@ -36,7 +36,7 @@ import org.syncany.operations.OperationResult;
  * <p>The methods typically take an {@link OperationOptions} instance as an argument, 
  * and return an instance of the {@link OperationResult} class.
  *  
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class Client {
 	protected static final String APPLICATION_PROPERTIES_RESOURCE = "/application.properties"; // TODO [low] Move this!

--- a/syncany-lib/src/main/java/org/syncany/chunk/Adler32Fingerprinter.java
+++ b/syncany-lib/src/main/java/org/syncany/chunk/Adler32Fingerprinter.java
@@ -28,7 +28,7 @@ package org.syncany.chunk;
  * <p>The class has been adapted to work with the Syncany chunking classes.
  *
  * @author Casey Marshall
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  * @version $Revision: 188 $
  */
 public class Adler32Fingerprinter extends Fingerprinter {

--- a/syncany-lib/src/main/java/org/syncany/chunk/Chunk.java
+++ b/syncany-lib/src/main/java/org/syncany/chunk/Chunk.java
@@ -21,7 +21,7 @@ package org.syncany.chunk;
  * A chunk represents a certain part of a file. It is created during the
  * deduplication process by a {@link Chunker}. 
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class Chunk {
     private byte[] checksum;

--- a/syncany-lib/src/main/java/org/syncany/chunk/Chunker.java
+++ b/syncany-lib/src/main/java/org/syncany/chunk/Chunker.java
@@ -29,7 +29,7 @@ import java.util.Enumeration;
  * <p>Note: Implementations should never read the entire file into memory at once,
  *          but instead use an input stream for processing.
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public abstract class Chunker {	
 	/**

--- a/syncany-lib/src/main/java/org/syncany/chunk/CipherTransformer.java
+++ b/syncany-lib/src/main/java/org/syncany/chunk/CipherTransformer.java
@@ -43,7 +43,7 @@ import org.syncany.util.StringUtil;
  * key. It can be instantiated using a property list (from a config file) or
  * by passing the dependencies to the constructor.
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class CipherTransformer extends Transformer {
 	public static final String TYPE = "cipher";

--- a/syncany-lib/src/main/java/org/syncany/chunk/Deduper.java
+++ b/syncany-lib/src/main/java/org/syncany/chunk/Deduper.java
@@ -41,7 +41,7 @@ import org.syncany.database.MultiChunkEntry.MultiChunkId;
  * multichunking: Syncany as an example"</i>
  * 
  * @see <a href="http://blog.philippheckel.com/2013/05/20/minimizing-remote-storage-usage-and-synchronization-time-using-deduplication-and-multichunking-syncany-as-an-example/">Blog post: Minimizing remote storage usage and synchronization time using deduplication and multichunking: Syncany as an example</a>
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class Deduper {	
 	private Chunker chunker;

--- a/syncany-lib/src/main/java/org/syncany/chunk/DeduperListener.java
+++ b/syncany-lib/src/main/java/org/syncany/chunk/DeduperListener.java
@@ -25,32 +25,32 @@ import org.syncany.database.MultiChunkEntry.MultiChunkId;
  * Listener interface used by the {@link Deduper} to notify the caller of file
  * events, and to retrieve information about chunks and output files. 
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public interface DeduperListener {
 	/**
 	 * Called by {@link Deduper} before a file is processed. This method can be 
-	 * used to ignore certain files. The method must return <tt>true</tt> if the deduper
-	 * shall continue processing, or <tt>false</tt> if a file should be skipped.
+	 * used to ignore certain files. The method must return <code>true</code> if the deduper
+	 * shall continue processing, or <code>false</code> if a file should be skipped.
 	 * 
-	 * <p>For files excluded by this method, neither {@link #onFileStart(File, int) onFileStart()} nor
+	 * <p>For files excluded by this method, neither {@link #onFileStart(File) onFileStart()} nor
 	 * {@link #onFileEnd(File, byte[]) onFileEnd()} are called.
 	 * 
 	 * @param file File that is evaluated by the filter
-	 * @return Returns <tt>true</tt> if the given file shall be processed, <tt>false</tt> otherwise 
+	 * @return Returns <code>true</code> if the given file shall be processed, <code>false</code> otherwise
 	 */
 	public boolean onFileFilter(File file);
 	
 	/**
 	 * Called by {@link Deduper} before the deduplication process is started, and before the
-	 * file is opened. The method must return <tt>true</tt> if the deduplication process should 
-	 * continue (e.g. for regular files), and <tt>false</tt> otherwise (e.g. for directories or
+	 * file is opened. The method must return <code>true</code> if the deduplication process should
+	 * continue (e.g. for regular files), and <code>false</code> otherwise (e.g. for directories or
 	 * symlink).
 	 * 
 	 * <p>The method is called for every file that was not excluded by {@link #onFileFilter(File) onFileFilter()}.
 	 * 
 	 * @param file File for which the deduplication process is about to be started
-	 * @return Returns <tt>true</tt> if the given file shall be deduplicated, <tt>false</tt> otherwise
+	 * @return Returns <code>true</code> if the given file shall be deduplicated, <code>false</code> otherwise
 	 */
 	public boolean onFileStart(File file);
 	
@@ -80,19 +80,19 @@ public interface DeduperListener {
 	/**
 	 * Called by {@link Deduper} during the deduplication process whenever then break condition 
 	 * of the {@link Chunker} was reached and a new {@link Chunk} was emitted. This method returns
-	 * <tt>true</tt> if the chunk is a new (and should be further processed), and <tt>false</tt>
+	 * <code>true</code> if the chunk is a new (and should be further processed), and <code>false</code>
 	 * otherwise.
 	 * 
 	 * <p>This method represents a query to the chunk index, i.e. it determines whether a chunk already exists
 	 * in the persistence layer. If it does, the chunk should not be added to a multichunk and processing should 
-	 * be stopped. Returning <tt>false</tt> has this effect. Returning <tt>true</tt> lets the deduper add the
+	 * be stopped. Returning <code>false</code> has this effect. Returning <code>true</code> lets the deduper add the
 	 * chunk to a multichunk.  
 	 * 
 	 * <p>The method is called zero to many times for every file, assuming that the file was not excluded
-	 * by {@link #onFileFilter(File) onFileFilter()}, or by {@link #onFileStart(File, int) onFileStart()}. 
+	 * by {@link #onFileFilter(File) onFileFilter()}, or by {@link #onFileStart(File) onFileStart()}.
 	 * 
 	 * @param chunk The new chunk that the chunker emitted
-	 * @return Returns <tt>true</tt> if the chunk is new, and <tt>false</tt> otherwise
+	 * @return Returns <code>true</code> if the chunk is new, and <code>false</code> otherwise
 	 */
 	public boolean onChunk(Chunk chunk); 
 	
@@ -144,7 +144,7 @@ public interface DeduperListener {
 	/**
 	 * Called by {@link Deduper} before starting the deduplication process.
 	 *  
-	 * @param size the number of files to be processed 
+	 * @param fileCount the number of files to be processed
 	 */
 	public void onStart(int fileCount);
 	

--- a/syncany-lib/src/main/java/org/syncany/chunk/Fingerprinter.java
+++ b/syncany-lib/src/main/java/org/syncany/chunk/Fingerprinter.java
@@ -29,7 +29,7 @@ import java.security.NoSuchAlgorithmException;
  * performance.
  * 
  * @see <a href="http://en.wikipedia.org/wiki/Rolling_hash">http://en.wikipedia.org/wiki/Rolling_hash</a>
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public abstract class Fingerprinter {    
     public static Fingerprinter getInstance(String name) throws NoSuchAlgorithmException {

--- a/syncany-lib/src/main/java/org/syncany/chunk/FixedChunker.java
+++ b/syncany-lib/src/main/java/org/syncany/chunk/FixedChunker.java
@@ -34,9 +34,9 @@ import java.util.logging.Logger;
  * performs very badly when bytes are added or removed from the beginning of a file.
  *
  * <p>Details can be found in chapter 3.4 of the thesis at <a href="http://blog.philippheckel.com/2013/05/20/minimizing-remote-storage-usage-and-synchronization-time-using-deduplication-and-multichunking-syncany-as-an-example/3/#Fixed-Size%20Chunking">blog.philippheckel.com</a>.
- * The <tt>FixedChunker</tt> implements the chunker described in chapter 3.4.2.
+ * The <code>FixedChunker</code> implements the chunker described in chapter 3.4.2.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class FixedChunker extends Chunker {
 	private static final Logger logger = Logger.getLogger(FixedChunker.class.getSimpleName());

--- a/syncany-lib/src/main/java/org/syncany/chunk/GzipTransformer.java
+++ b/syncany-lib/src/main/java/org/syncany/chunk/GzipTransformer.java
@@ -29,7 +29,7 @@ import java.util.zip.GZIPOutputStream;
  * Implements a {@link Transformer} that transforms the input/output stream
  * using the Gzip compression algorithm.
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class GzipTransformer extends Transformer {
     public static final String TYPE = "gzip";

--- a/syncany-lib/src/main/java/org/syncany/chunk/MultiChunk.java
+++ b/syncany-lib/src/main/java/org/syncany/chunk/MultiChunk.java
@@ -40,7 +40,7 @@ import org.syncany.database.MultiChunkEntry.MultiChunkId;
  *      <b>it is essential that random read access on a multichunk is possible</b>.
  * </ul>
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public abstract class MultiChunk {
 	protected MultiChunkId id;
@@ -92,12 +92,12 @@ public abstract class MultiChunk {
 	/**
 	 * In read mode, this method can be used to <b>sequentially</b> read {@link Chunk}s from a multichunk.
 	 * The method returns a chunk until no more chunks are available, at which point it will return
-	 * <tt>null</tt>.
+	 * <code>null</code>.
 	 *
 	 * <p>If random read access on a multichunk is desired, the
 	 * {@link #getChunkInputStream(byte[]) getChunkInputStream()} method should be used instead.
 	 *
-	 * @return Returns the next chunk in the opened multichunk, or <tt>null</tt> if no chunk is available (anymore)
+	 * @return Returns the next chunk in the opened multichunk, or <code>null</code> if no chunk is available (anymore)
 	 * @throws IOException If an exception occurs when reading from the multichunk
 	 */
 	// TODO [low] Method is only used by tests, not necessary anymore? Required for 'cleanup'?
@@ -106,12 +106,12 @@ public abstract class MultiChunk {
 	/**
 	 * In read mode, this method can be used to read {@link Chunk}s in <b>random access mode</b>, using a chunk
 	 * checksum as identifier. The method returns a chunk input stream (the chunk's data) if the chunk is
-	 * found, and <tt>null</tt> otherwise.
+	 * found, and <code>null</code> otherwise.
 	 *
 	 * <p>If all chunks are read from a multichunk sequentially, the {@link #read()} method should be used instead.
 	 *
 	 * @param checksum The checksum identifying a chunk instance
-	 * @return Returns a chunk input stream (chunk data) if the chunk can be found in the multichunk, or <tt>null</tt> otherwise
+	 * @return Returns a chunk input stream (chunk data) if the chunk can be found in the multichunk, or <code>null</code> otherwise
 	 * @throws IOException If an exception occurs when reading from the multichunk
 	 */
 	// TODO [low] Method should be named 'read(checksum)' and return a Chunk object, not an input stream, right?!
@@ -132,7 +132,7 @@ public abstract class MultiChunk {
 	 * returns whether or not a new chunk can still be added. It is used by the
 	 * {@link Deduper}.
 	 *
-	 * @return Returns <tt>true</tt> if no more chunks should be added and the chunk should be closed, <tt>false</tt> otherwise
+	 * @return Returns <code>true</code> if no more chunks should be added and the chunk should be closed, <code>false</code> otherwise
 	 */
 	public boolean isFull() {
 		return size >= minSize;

--- a/syncany-lib/src/main/java/org/syncany/chunk/MultiChunker.java
+++ b/syncany-lib/src/main/java/org/syncany/chunk/MultiChunker.java
@@ -37,7 +37,7 @@ import org.syncany.util.StringUtil;
  * <p>The class supports two modes: 
  * 
  * <ul>
- * <li>When writing a {@link MultiChunker}, the {@link #createMultiChunk(byte[], OutputStream)}
+ * <li>When writing a {@link MultiChunker}, the {@link #createMultiChunk(MultiChunkId, OutputStream)}
  *     must be used. The method emits a new implementation-specific {@link MultiChunk} 
  *     to which new chunks can be added/written to.
  *      
@@ -49,7 +49,7 @@ import org.syncany.util.StringUtil;
  * the individual chunk objects must be randomly accessible. A sequential read (like with TAR, for
  * instance), is not sufficient for the quick processing required in the application.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 // TODO [low] The multichunk API is really odd; Think of something more sensible
 public abstract class MultiChunker {
@@ -138,7 +138,7 @@ public abstract class MultiChunker {
 	 * <p>Using this method only allows reading from the returned multichunk. The underlying
 	 * input stream is opened and can be used to retrieve chunk data.
 	 * 
-	 * @param is InputStream to initialize an existing multichunk for read-operations only
+	 * @param file File to read into a multichunk for read-operations only
 	 * @return Returns an existing multichunk object that allows read operations only
 	 */
 	public abstract MultiChunk createMultiChunk(File file) throws IOException;
@@ -153,12 +153,11 @@ public abstract class MultiChunker {
 	 * <br>
 	 * After creating a new multichunker, it must be initialized using the 
 	 * {@link #init(Map) init()} method. The given type attribute is mapped to fully 
-	 * qualified class name (FQCN) of the form <tt>org.syncany.chunk.XMultiChunker</tt>, 
-	 * where <tt>X</tt> is the camel-cased type attribute.  
+	 * qualified class name (FQCN) of the form <code>org.syncany.chunk.XMultiChunker</code>,
+	 * where <code>X</code> is the camel-cased type attribute.
 	 * 
 	 * @param type Type/name of the multichunker (corresponds to its camel case class name)
 	 * @return a new multichunker
-	 * @throws Exception If the FQCN cannot be found or the class cannot be instantiated
 	 */
 	public static MultiChunker getInstance(String type) {
 		String thisPackage = MultiChunker.class.getPackage().getName();

--- a/syncany-lib/src/main/java/org/syncany/chunk/NoTransformer.java
+++ b/syncany-lib/src/main/java/org/syncany/chunk/NoTransformer.java
@@ -26,7 +26,7 @@ import java.util.Map;
  * Implements an empty {@link Transformer}. Used if no compression/encryption
  * is necessary.
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class NoTransformer extends Transformer {
 	/**

--- a/syncany-lib/src/main/java/org/syncany/chunk/Transformer.java
+++ b/syncany-lib/src/main/java/org/syncany/chunk/Transformer.java
@@ -38,7 +38,7 @@ import org.syncany.util.StringUtil;
  * its default constructor and initializing it using the {@link #init(Map) init()} method. Depending
  * on the implementation, varying settings must be passed.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public abstract class Transformer {
 	private static final Logger logger = Logger.getLogger(Transformer.class.getSimpleName());
@@ -103,7 +103,7 @@ public abstract class Transformer {
 	 * a new transformer, it must be initialized using the {@link #init(Map) init()} method.  
 	 * 
 	 * <p>The given type attribute is mapped to fully qualified class name (FQCN) of the form
-	 * <tt>org.syncany.chunk.XTransformer</tt>, where <tt>X</tt> is the camel-cased type
+	 * <code>org.syncany.chunk.XTransformer</code>, where <code>X</code> is the camel-cased type
 	 * attribute.  
 	 * 
 	 * @param type Type/name of the transformer (corresponds to its camel case class name)

--- a/syncany-lib/src/main/java/org/syncany/chunk/TttdChunker.java
+++ b/syncany-lib/src/main/java/org/syncany/chunk/TttdChunker.java
@@ -50,7 +50,7 @@ import java.util.logging.Logger;
  * breakpoints, TTTD simply cuts the chunk at the maximum chunk size. TTTD hence guarantees
  * to emit chunks with a minimum and maximum size.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  * @see <a href="http://www.hpl.hp.com/techreports/2005/HPL-2005-30R1.html">Original TTTD paper: A framework for analyzing and improving content-based chunking algorithms (2005, Kave Eshghi and Hsiu Khuern Tang)</a>
  */
 public class TttdChunker extends Chunker {
@@ -83,7 +83,7 @@ public class TttdChunker extends Chunker {
 
 	/**
 	 * Infer the optimal values for avgChunkSize from the orginal paper's optimal (measured) values.
-	 * LBFS: avg. chunk size = 1015 bytes --> Tmin = 460, Tmax = 2800, D = 540, Ddash = 270
+	 * LBFS: avg. chunk size = 1015 bytes --&gt; Tmin = 460, Tmax = 2800, D = 540, Ddash = 270
 	 */
 	public TttdChunker(int avgChunkSize, int windowSize, String digestAlg, String fingerprintAlg) {
 		this(

--- a/syncany-lib/src/main/java/org/syncany/chunk/ZipMultiChunk.java
+++ b/syncany-lib/src/main/java/org/syncany/chunk/ZipMultiChunk.java
@@ -33,7 +33,7 @@ import org.syncany.util.StringUtil;
 
 /**
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class ZipMultiChunk extends MultiChunk {
     private ZipOutputStream zipOut;

--- a/syncany-lib/src/main/java/org/syncany/config/Cache.java
+++ b/syncany-lib/src/main/java/org/syncany/config/Cache.java
@@ -40,7 +40,7 @@ import org.syncany.database.MultiChunkEntry.MultiChunkId;
  * date is updated. Using the {@link #clear()}/{@link #clear(long)} method, the cache
  * can be cleaned.
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class Cache {
 	private static final Logger logger = Logger.getLogger(Cache.class.getSimpleName());
@@ -90,8 +90,8 @@ public class Cache {
 	}
 
 	/**
-	 * Deletes files in the the cache directory using a LRU-strategy until <tt>keepBytes</tt>
-	 * bytes are left. This method calls {@link #clear(long)} using the <tt>keepBytes</tt> 
+	 * Deletes files in the the cache directory using a LRU-strategy until <code>keepBytes</code>
+	 * bytes are left. This method calls {@link #clear(long)} using the <code>keepBytes</code>
 	 * property.
 	 * 
 	 * <p>This method should not be run while an operation is executed.
@@ -101,7 +101,7 @@ public class Cache {
 	}
 	
 	/**
-	 * Deletes files in the the cache directory using a LRU-strategy until <tt>keepBytes</tt>
+	 * Deletes files in the the cache directory using a LRU-strategy until <code>keepBytes</code>
 	 * bytes are left.
 	 * 
 	 * <p>This method should not be run while an operation is executed.

--- a/syncany-lib/src/main/java/org/syncany/config/Config.java
+++ b/syncany-lib/src/main/java/org/syncany/config/Config.java
@@ -45,10 +45,10 @@ import org.syncany.util.StringUtil;
  * used in the operations, but parts of it are also used in other parts of the
  * application -- especially file locations and names.
  *
- * <p>An instance of the <tt>Config</tt> class must be created through the transfer
+ * <p>An instance of the <code>Config</code> class must be created through the transfer
  * objects {@link ConfigTO} and {@link RepoTO}.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class Config {
 	public static final String DIR_APPLICATION = ".syncany";

--- a/syncany-lib/src/main/java/org/syncany/config/ConfigException.java
+++ b/syncany-lib/src/main/java/org/syncany/config/ConfigException.java
@@ -21,7 +21,7 @@ package org.syncany.config;
  * Exception thrown when configuration files are read or written 
  * and something is going not as expected.
  *  
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class ConfigException extends Exception {
 	private static final long serialVersionUID = 4414807565457521855L;

--- a/syncany-lib/src/main/java/org/syncany/config/ConfigHelper.java
+++ b/syncany-lib/src/main/java/org/syncany/config/ConfigHelper.java
@@ -35,7 +35,7 @@ import org.syncany.plugins.transfer.TransferPlugin;
  * The config helper provides convenience functions to load the configuration from
  * the local application repo.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class ConfigHelper {
 	private static final Logger logger = Logger.getLogger(ConfigHelper.class.getSimpleName());
@@ -43,7 +43,7 @@ public class ConfigHelper {
 	/**
 	 * Loads a {@link Config} object from the given local directory.
 	 *
-	 * <p>If the config file (.syncany/config.xml) does not exist, <tt>null</tt>
+	 * <p>If the config file (.syncany/config.xml) does not exist, <code>null</code>
 	 * is returned. If it does, the method tries to do the following:
 	 * <ul>
 	 *  <li>Load the .syncany/config.xml file and load the plugin given by the config file</li>
@@ -51,9 +51,9 @@ public class ConfigHelper {
 	 *  <li>Instantiate a {@link Config} object with the transfer objects</li>
 	 * </ul>
 	 *
-	 * @return Returns an instantiated {@link Config} object, or <tt>null</tt> if
+	 * @return Returns an instantiated {@link Config} object, or <code>null</code> if
 	 *         the config file does not exist
-	 * @throws Throws an exception if the config is invalid
+	 * @throws ConfigException an exception if the config is invalid
 	 */
 	public static Config loadConfig(File localDir) throws ConfigException {
 		if (localDir == null) {
@@ -137,7 +137,7 @@ public class ConfigHelper {
     /**
      * Helper method to find the local sync directory, starting from a path equal
      * or inside the local sync directory. If the starting path is not inside or equal
-     * to the local directory, <tt>null</tt> is returned.
+     * to the local directory, <code>null</code> is returned.
      *
      * <p>To find the local directory, the method looks for a file named
      * "{@link Config#DIR_APPLICATION}/{@link Config#FILE_CONFIG}". If it is found, it stops.
@@ -153,7 +153,7 @@ public class ConfigHelper {
      * </ul>
      *
      * @param startingPath Path to start the search from
-     * @return Returns the local directory (if found), or <tt>null</tt> otherwise
+     * @return Returns the local directory (if found), or <code>null</code> otherwise
      */
     public static File findLocalDirInPath(File startingPath) {
     	try {

--- a/syncany-lib/src/main/java/org/syncany/config/DaemonConfigHelper.java
+++ b/syncany-lib/src/main/java/org/syncany/config/DaemonConfigHelper.java
@@ -39,8 +39,8 @@ import com.google.common.primitives.Ints;
  * The daemon helper provides helper functions to read and/or write the
  * daemon configuration file as defined by {@link DaemonConfigTO}.
  *
- * @author Vincent Wiencek <vwiencek@gmail.com>
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Vincent Wiencek (vwiencek@gmail.com)
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class DaemonConfigHelper {
 	private static final Logger logger = Logger.getLogger(DaemonConfigHelper.class.getSimpleName());
@@ -57,18 +57,18 @@ public class DaemonConfigHelper {
 	}
 
 	/**
-	 * Adds the given folder to the user-specific daemon configuration (<tt>daemon.xml</tt>).
+	 * Adds the given folder to the user-specific daemon configuration (<code>daemon.xml</code>).
 	 *
 	 * <p>The method first reads the daemon configuration, checks if the folder is already present
 	 * and adds it if it is not. If no daemon config file exists, a new default config file is created
 	 * via {@link #createAndWriteDefaultDaemonConfig(File)}. If the folder is already present in
-	 * the current daemon config, <tt>false</tt> is returned. If an error occurs (e.g. an I/O error
+	 * the current daemon config, <code>false</code> is returned. If an error occurs (e.g. an I/O error
 	 * or an invalid XML file), a {@link ConfigException} is thrown. If the folder was successfully added,
-	 * <tt>true</tt> is returned.
+	 * <code>true</code> is returned.
 	 *
 	 * @param localDir Absolute path of the local folder to add to the daemon config
-	 * @return Returns <tt>true</tt> if the folder was successfully added to the daemon config,
-	 *         <tt>false</tt> otherwise
+	 * @return Returns <code>true</code> if the folder was successfully added to the daemon config,
+	 *         <code>false</code> otherwise
 	 * @throws ConfigException If an error occurs, e.g. an I/O error or an invalid XML file
 	 */
 	public static boolean addFolder(File localDir) throws ConfigException {

--- a/syncany-lib/src/main/java/org/syncany/config/InternalEventBus.java
+++ b/syncany-lib/src/main/java/org/syncany/config/InternalEventBus.java
@@ -29,7 +29,7 @@ import com.google.common.eventbus.EventBus;
  * daemon. It provides a publish/subscribe mechanism within a
  * single JVM.
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 //TODO [medium] This class belongs in the 'util' package
 public abstract class InternalEventBus {

--- a/syncany-lib/src/main/java/org/syncany/config/LocalEventBus.java
+++ b/syncany-lib/src/main/java/org/syncany/config/LocalEventBus.java
@@ -24,7 +24,7 @@ package org.syncany.config;
  * <p>It is heavily used by the daemon to distribute requests and responses
  * into the application; and to pass responses back to the daemon. 
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 // TODO [medium] This class belongs in the 'util' package
 public class LocalEventBus extends InternalEventBus {	

--- a/syncany-lib/src/main/java/org/syncany/config/LogFormatter.java
+++ b/syncany-lib/src/main/java/org/syncany/config/LogFormatter.java
@@ -44,7 +44,7 @@ import java.util.logging.LogRecord;
  * Instead, it can be referenced (and instantiated) using a logging.properties
  * file.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class LogFormatter extends Formatter {
 	private DateFormat dateFormat;

--- a/syncany-lib/src/main/java/org/syncany/config/Logging.java
+++ b/syncany-lib/src/main/java/org/syncany/config/Logging.java
@@ -30,11 +30,11 @@ import java.util.logging.Logger;
  * application's log options. 
  * 
  * <p>In particular, it can load the log properties either from a resource or a
- * local file on the file system (<tt>logging.properties</tt>. If a local file is
+ * local file on the file system (<code>logging.properties</code>. If a local file is
  * present, it is preferred over the JAR resource.
  * 
  * <p>To initialize logging, the {@link #init()} method can be called in the 
- * <tt>static</tt> block of a class, e.g.
+ * <code>static</code> block of a class, e.g.
  * 
  * <pre>
  *   static {
@@ -42,7 +42,7 @@ import java.util.logging.Logger;
  *   }
  * </pre>
  *  
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class Logging {
 	private static final String LOG_PROPERTIES_JAR_RESOURCE = "/" + Logging.class.getPackage().getName().replace(".", "/") + "/logging.properties";	

--- a/syncany-lib/src/main/java/org/syncany/config/UserConfig.java
+++ b/syncany-lib/src/main/java/org/syncany/config/UserConfig.java
@@ -35,7 +35,7 @@ import org.syncany.util.EnvironmentUtil;
  * of the currently logged in user, including system properties that will be
  * set with every application start.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class UserConfig {
 	/*

--- a/syncany-lib/src/main/java/org/syncany/config/to/ConfigTO.java
+++ b/syncany-lib/src/main/java/org/syncany/config/to/ConfigTO.java
@@ -42,7 +42,7 @@ import org.syncany.plugins.transfer.TransferSettings;
  * annotation-based configuration.
  *
  * @see <a href="http://simple.sourceforge.net/">Simple framework</a>
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 @Root(name = "config", strict = false)
 public class ConfigTO {

--- a/syncany-lib/src/main/java/org/syncany/config/to/DaemonConfigTO.java
+++ b/syncany-lib/src/main/java/org/syncany/config/to/DaemonConfigTO.java
@@ -37,7 +37,7 @@ import org.syncany.config.ConfigException;
  * @see FolderTO
  * @see PortTO
  * @see <a href="http://simple.sourceforge.net/">Simple framework</a>
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 @Root(name = "daemon", strict = false)
 public class DaemonConfigTO {

--- a/syncany-lib/src/main/java/org/syncany/config/to/DefaultRepoTOFactory.java
+++ b/syncany-lib/src/main/java/org/syncany/config/to/DefaultRepoTOFactory.java
@@ -41,7 +41,7 @@ import org.syncany.util.StringUtil.StringJoinListener;
  * MultiChunkers. The transformers are configurable, namely whether or not compression is used
  * and how it is encrypted.
  * 
- * @author Pim Otte <otte.pim@gmail.com>
+ * @author Pim Otte (otte.pim@gmail.com)
  */
 public class DefaultRepoTOFactory implements RepoTOFactory {
 	private ChunkerTO chunkerTO;

--- a/syncany-lib/src/main/java/org/syncany/config/to/FolderTO.java
+++ b/syncany-lib/src/main/java/org/syncany/config/to/FolderTO.java
@@ -32,7 +32,7 @@ import org.syncany.operations.watch.WatchOperationOptions;
  * annotation-based configuration.
  *
  * @see <a href="http://simple.sourceforge.net/">Simple framework</a>
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 @Root(strict = false)
 public class FolderTO {

--- a/syncany-lib/src/main/java/org/syncany/config/to/MasterTO.java
+++ b/syncany-lib/src/main/java/org/syncany/config/to/MasterTO.java
@@ -39,7 +39,7 @@ import org.syncany.util.StringUtil;
  * annotation-based configuration.
  *
  * @see <a href="http://simple.sourceforge.net/">Simple framework</a>
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 @Root(name = "master", strict = false)
 public class MasterTO {

--- a/syncany-lib/src/main/java/org/syncany/config/to/RepoTO.java
+++ b/syncany-lib/src/main/java/org/syncany/config/to/RepoTO.java
@@ -48,7 +48,7 @@ import org.syncany.util.StringUtil;
  * annotation-based configuration.
  *
  * @see <a href="http://simple.sourceforge.net/">Simple framework</a>
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 @Root(name = "repo", strict = false)
 public class RepoTO {

--- a/syncany-lib/src/main/java/org/syncany/config/to/RepoTOFactory.java
+++ b/syncany-lib/src/main/java/org/syncany/config/to/RepoTOFactory.java
@@ -22,7 +22,7 @@ package org.syncany.config.to;
  * repoTO's have a couple of moving and standing parts. (Chunkers, MultiChunkers and Transformers),
  * which all may or may not be configurable.
  * 
- * @author Pim Otte <otte.pim@gmail.com>
+ * @author Pim Otte (otte.pim@gmail.com)
  */
 public interface RepoTOFactory {
 	public RepoTO createRepoTO();

--- a/syncany-lib/src/main/java/org/syncany/config/to/TypedPropertyListTO.java
+++ b/syncany-lib/src/main/java/org/syncany/config/to/TypedPropertyListTO.java
@@ -33,7 +33,7 @@ import org.simpleframework.xml.ElementMap;
  * annotation-based configuration.  
  *  
  * @see <a href="http://simple.sourceforge.net/">Simple framework</a>
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public abstract class TypedPropertyListTO {
 	@Attribute(required=true)

--- a/syncany-lib/src/main/java/org/syncany/config/to/UserConfigTO.java
+++ b/syncany-lib/src/main/java/org/syncany/config/to/UserConfigTO.java
@@ -39,7 +39,7 @@ import org.syncany.crypto.SaltedSecretKeyConverter;
  * annotation-based configuration.
  *
  * @see <a href="http://simple.sourceforge.net/">Simple framework</a>
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 @Root(name = "userConfig", strict = false)
 public class UserConfigTO {

--- a/syncany-lib/src/main/java/org/syncany/config/to/WebServerTO.java
+++ b/syncany-lib/src/main/java/org/syncany/config/to/WebServerTO.java
@@ -30,7 +30,7 @@ import org.simpleframework.xml.Root;
  * annotation-based configuration.
  *
  * @see <a href="http://simple.sourceforge.net/">Simple framework</a>
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 @Root(strict = false)
 public class WebServerTO {

--- a/syncany-lib/src/main/java/org/syncany/crypto/CipherException.java
+++ b/syncany-lib/src/main/java/org/syncany/crypto/CipherException.java
@@ -21,7 +21,7 @@ package org.syncany.crypto;
  * Exception thrown when content cannot encrypted or decrypted,
  * or other cryptographic operations fail.
  *  
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class CipherException extends Exception {
 	private static final long serialVersionUID = -4974450231162263359L;

--- a/syncany-lib/src/main/java/org/syncany/crypto/CipherParams.java
+++ b/syncany-lib/src/main/java/org/syncany/crypto/CipherParams.java
@@ -31,7 +31,7 @@ import org.syncany.util.StringUtil;
  * invalidated ciphertext data. Do <b>not change</b> any of these parameters unless 
  * you know what you are doing!
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public abstract class CipherParams {
 	/**

--- a/syncany-lib/src/main/java/org/syncany/crypto/CipherSession.java
+++ b/syncany-lib/src/main/java/org/syncany/crypto/CipherSession.java
@@ -52,7 +52,7 @@ import org.syncany.util.StringUtil;
  *       files are processed.
  * </ul>
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class CipherSession {
 	private static final Logger logger = Logger.getLogger(CipherSession.class.getSimpleName());

--- a/syncany-lib/src/main/java/org/syncany/crypto/CipherSpec.java
+++ b/syncany-lib/src/main/java/org/syncany/crypto/CipherSpec.java
@@ -36,7 +36,7 @@ import java.util.regex.Pattern;
  * <p>Instantiating a cipher spec that does pass the sanity checks will result in a
  * RuntimeException.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public abstract class CipherSpec {
 	public static final Pattern ALLOWED_CIPHER_ALGORITHMS = Pattern.compile("^HmacSHA256$|(^(AES|Twofish)/(GCM|EAX)/.+)");

--- a/syncany-lib/src/main/java/org/syncany/crypto/CipherSpecs.java
+++ b/syncany-lib/src/main/java/org/syncany/crypto/CipherSpecs.java
@@ -47,7 +47,7 @@ import org.syncany.crypto.specs.TwofishGcm256CipherSpec;
  *       not require an IV (e.g. ECB) will be rejected by the {@link CipherSpec} sanity checks.
  * </ul>
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class CipherSpecs {
 	private static final Map<Integer, CipherSpec> cipherSpecs = new TreeMap<Integer, CipherSpec>();
@@ -105,7 +105,7 @@ public class CipherSpecs {
 	 * defined in this class.
 	 * 
 	 * @param id Identifier of the cipher spec
-	 * @return A cipher spec, or <tt>null</tt> if no cipher spec with this identifier is registered
+	 * @return A cipher spec, or <code>null</code> if no cipher spec with this identifier is registered
 	 */
 	public static CipherSpec getCipherSpec(int id) {
 		return cipherSpecs.get(id);

--- a/syncany-lib/src/main/java/org/syncany/crypto/CipherUtil.java
+++ b/syncany-lib/src/main/java/org/syncany/crypto/CipherUtil.java
@@ -84,7 +84,7 @@ import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
  * It furthermore offers a method to programmatically enable the unlimited strength
  * crypto policies.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class CipherUtil {
 	private static final Logger logger = Logger.getLogger(CipherUtil.class.getSimpleName());
@@ -110,7 +110,7 @@ public class CipherUtil {
 	 * strength policy has been enabled. Unlimited crypto allows for stronger crypto algorithms
 	 * such as AES-256 or Twofish-256.
 	 *
-	 * <p>The method is called in the <tt>static</tt> block of this class and hence initialized
+	 * <p>The method is called in the <code>static</code> block of this class and hence initialized
 	 * whenever then class is used.
 	 *
 	 * @see <a href="www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java Cryptography Extension (JCE) Unlimited Strength</a>
@@ -139,8 +139,8 @@ public class CipherUtil {
 	 * Attempts to programmatically enable the unlimited strength Java crypto extension
 	 * using the reflection API.
 	 *
-	 * <p>This class tries to set the property <tt>isRestricted</tt> of the class
-	 * <tt>javax.crypto.JceSecurity</tt> to <tt>false</tt> -- effectively disabling
+	 * <p>This class tries to set the property <code>isRestricted</code> of the class
+	 * <code>javax.crypto.JceSecurity</code> to <code>false</code> -- effectively disabling
 	 * the artificial limitations (and the disallowed algorithms).
 	 *
 	 * <p><b>Note</b>: Be aware that enabling the unlimited strength extension needs to

--- a/syncany-lib/src/main/java/org/syncany/crypto/SaltedSecretKey.java
+++ b/syncany-lib/src/main/java/org/syncany/crypto/SaltedSecretKey.java
@@ -28,7 +28,7 @@ import org.syncany.util.StringUtil;
  * its corresponding salt. It is mainly used to represent the master key and the
  * master key salt.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class SaltedSecretKey implements SecretKey {
 	private static final long serialVersionUID = 1216126055360327470L;

--- a/syncany-lib/src/main/java/org/syncany/crypto/SaltedSecretKeyConverter.java
+++ b/syncany-lib/src/main/java/org/syncany/crypto/SaltedSecretKeyConverter.java
@@ -28,7 +28,7 @@ import org.syncany.util.StringUtil;
  * Converter to properly encode a {@link SaltedSecretKey} when writing 
  * an XML. Salt and key are serialized as attributes.
  * 
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Christian Roth (christian.roth@port17.de)
  */
 public class SaltedSecretKeyConverter implements Converter<SaltedSecretKey> {
 	public SaltedSecretKey read(InputNode node) throws Exception {

--- a/syncany-lib/src/main/java/org/syncany/database/ChunkEntry.java
+++ b/syncany-lib/src/main/java/org/syncany/database/ChunkEntry.java
@@ -26,7 +26,7 @@ package org.syncany.database;
  *
  * @see MultiChunkEntry
  * @see FileContent
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class ChunkEntry {
 	private ChunkChecksum checksum;

--- a/syncany-lib/src/main/java/org/syncany/database/DatabaseConnectionFactory.java
+++ b/syncany-lib/src/main/java/org/syncany/database/DatabaseConnectionFactory.java
@@ -43,7 +43,7 @@ import org.syncany.util.SqlRunner;
  * SQL statements from the resources, and create the initial tables when the
  * application is first started.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class DatabaseConnectionFactory {
 	private static final Logger logger = Logger.getLogger(DatabaseConnectionFactory.class.getSimpleName());

--- a/syncany-lib/src/main/java/org/syncany/database/DatabaseVersion.java
+++ b/syncany-lib/src/main/java/org/syncany/database/DatabaseVersion.java
@@ -31,7 +31,7 @@ import org.syncany.database.PartialFileHistory.FileHistoryId;
  * The database version represents an incremental addition to the local database of
  * a client. A user's {@link MemoryDatabase} consists of many incremental database versions.
  *
- * <p>A <tt>DatabaseVersion</tt> is identified by a {@link DatabaseVersionHeader}, a
+ * <p>A <code>DatabaseVersion</code> is identified by a {@link DatabaseVersionHeader}, a
  * combination of a {@link VectorClock}, a local timestamp and the original client name.
  *
  * <p>The database version holds references to the newly added/removed/changed
@@ -40,7 +40,7 @@ import org.syncany.database.PartialFileHistory.FileHistoryId;
  *
  * <p>The current implementation of the database version keeps all references in memory.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class DatabaseVersion {
 	public enum DatabaseVersionStatus {

--- a/syncany-lib/src/main/java/org/syncany/database/DatabaseVersionHeader.java
+++ b/syncany-lib/src/main/java/org/syncany/database/DatabaseVersionHeader.java
@@ -27,7 +27,7 @@ import java.util.Date;
  * reconciliation process, in particular when trying to find a winning
  * branch.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class DatabaseVersionHeader {
 	private Date date;

--- a/syncany-lib/src/main/java/org/syncany/database/FileContent.java
+++ b/syncany-lib/src/main/java/org/syncany/database/FileContent.java
@@ -35,7 +35,7 @@ import org.syncany.database.ChunkEntry.ChunkChecksum;
  * is very important, because a file can only be reconstructed if the order of
  * its chunks are followed.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class FileContent {
 	private FileChecksum checksum;

--- a/syncany-lib/src/main/java/org/syncany/database/FileVersion.java
+++ b/syncany-lib/src/main/java/org/syncany/database/FileVersion.java
@@ -27,15 +27,15 @@ import org.syncany.database.PartialFileHistory.FileHistoryId;
  * A file version represents a version of a file at a certain time and captures
  * all of a file's properties.
  *
- * <p>A {@link PartialFileHistory} typically consists of multiple <tt>FileVersion</tt>s,
+ * <p>A {@link PartialFileHistory} typically consists of multiple <code>FileVersion</code>s,
  * each of which is the incarnation of the same file, but with either changed properties,
  * or changed content.
  *
- * <p>The <tt>FileVersion</tt>'s checksum attribute implicitly links to a {@link FileContent},
+ * <p>The <code>FileVersion</code>'s checksum attribute implicitly links to a {@link FileContent},
  * which represents the content of a file. Multiple file versions can link to the same file content.
  *
  * @see PartialFileHistory
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class FileVersion implements Cloneable {
 	// Optional

--- a/syncany-lib/src/main/java/org/syncany/database/FileVersionComparator.java
+++ b/syncany-lib/src/main/java/org/syncany/database/FileVersionComparator.java
@@ -352,12 +352,12 @@ public class FileVersionComparator {
 
 		// Check existence
 		if (fileComparison.expectedFileProperties.exists() != fileComparison.actualFileProperties.exists()) {
-			// File is expected to exist, but it does NOT --&gt; file has been deleted
+			// File is expected to exist, but it does NOT --> file has been deleted
 			if (fileComparison.expectedFileProperties.exists() && !fileComparison.actualFileProperties.exists()) {
 				fileComparison.fileChanges.add(FileChange.DELETED);
 			}
 
-			// File is expected to NOT exist, but it does --&gt; file is new
+			// File is expected to NOT exist, but it does --> file is new
 			else {
 				fileComparison.fileChanges.add(FileChange.NEW);
 			}

--- a/syncany-lib/src/main/java/org/syncany/database/FileVersionComparator.java
+++ b/syncany-lib/src/main/java/org/syncany/database/FileVersionComparator.java
@@ -46,7 +46,7 @@ import org.syncany.util.FileUtil;
  * other, or compare {@link FileVersion}s to local {@link File}s.
  *
  * <p>It captures the {@link FileProperties} of two files or file versions and compares them
- * using the various <tt>compare*</tt>-methods. A comparison returns a set of {@link FileChange}s,
+ * using the various <code>compare*</code>-methods. A comparison returns a set of {@link FileChange}s,
  * each of which identifies a certain attribute change (e.g. checksum changed, name changed).
  * A file can be considered equal if the returned set of {@link FileChange}s is empty.
  *
@@ -56,7 +56,7 @@ import org.syncany.util.FileUtil;
  * sense (e.g. new vs. deleted files or files vs. folders). If a cancelling test is not successful,
  * other tests are not performed.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class FileVersionComparator {
 	private static final Logger logger = Logger.getLogger(FileVersionComparator.class.getSimpleName());
@@ -66,8 +66,8 @@ public class FileVersionComparator {
 	/**
 	 * Creates a new file version comparator helper class.
 	 *
-	 * <p>The <tt>rootFolder</tt> is needed to allow a comparison of the relative file path.
-	 * The <tt>checksumAlgorithm</tt> is used for calculate and compare file checksums. Both
+	 * <p>The <code>rootFolder</code> is needed to allow a comparison of the relative file path.
+	 * The <code>checksumAlgorithm</code> is used for calculate and compare file checksums. Both
 	 * are used if a local {@link File} is compared to a {@link FileVersion}.
 	 *
 	 * @param rootFolder Base folder to determine a relative path to
@@ -97,7 +97,7 @@ public class FileVersionComparator {
 	 *
 	 * <p>If the actual file does not differ in size, it is necessary to calculate and compare the checksum of the
 	 * local file to the file version to reliably determine if it has changed. Unless comparing the size and last
-	 * modified date is enough, the <tt>actualFileForceChecksum</tt> parameter must be switched to <tt>true</tt>.
+	 * modified date is enough, the <code>actualFileForceChecksum</code> parameter must be switched to <code>true</code>.
 	 *
 	 * @param expectedFileVersion The expected file version (that is compared to the actual file)
 	 * @param actualFile The actual file (that is compared to the expected file version)
@@ -113,14 +113,14 @@ public class FileVersionComparator {
 	 *
 	 * <p>If the actual file does not differ in size, it is necessary to calculate and compare the checksum of the
 	 * local file to the file version to reliably determine if it has changed. Unless comparing the size and last
-	 * modified date is enough, the <tt>actualFileForceChecksum</tt> parameter must be switched to <tt>true</tt>.
+	 * modified date is enough, the <code>actualFileForceChecksum</code> parameter must be switched to <code>true</code>.
 	 *
-	 * <p>If the <tt>actualFileKnownChecksum</tt> parameter is set and a checksum comparison is necessary, this
+	 * <p>If the <code>actualFileKnownChecksum</code> parameter is set and a checksum comparison is necessary, this
 	 * parameter is used to compare checksums. If not and force checksum is enabled, the checksum is calculated
 	 * and compared.
 	 *
-	 * @param expectedFileVersion The expected file version (that is compared to the actual file)
-	 * @param actualFile The actual file (that is compared to the expected file version)
+	 * @param expectedLocalFileVersion The expected file version (that is compared to the actual file)
+	 * @param actualLocalFile The actual file (that is compared to the expected file version)
 	 * @param actualFileKnownChecksum If the checksum of the local file is known, it can be set
 	 * @param actualFileForceChecksum Force a checksum comparison if necessary (if size does not differ)
 	 * @return Returns a file version comparison object, indicating if there are differences between the file versions
@@ -352,12 +352,12 @@ public class FileVersionComparator {
 
 		// Check existence
 		if (fileComparison.expectedFileProperties.exists() != fileComparison.actualFileProperties.exists()) {
-			// File is expected to exist, but it does NOT --> file has been deleted
+			// File is expected to exist, but it does NOT --&gt; file has been deleted
 			if (fileComparison.expectedFileProperties.exists() && !fileComparison.actualFileProperties.exists()) {
 				fileComparison.fileChanges.add(FileChange.DELETED);
 			}
 
-			// File is expected to NOT exist, but it does --> file is new
+			// File is expected to NOT exist, but it does --&gt; file is new
 			else {
 				fileComparison.fileChanges.add(FileChange.NEW);
 			}

--- a/syncany-lib/src/main/java/org/syncany/database/MemoryDatabase.java
+++ b/syncany-lib/src/main/java/org/syncany/database/MemoryDatabase.java
@@ -39,14 +39,14 @@ import org.syncany.database.PartialFileHistory.FileHistoryId;
  * collection of changes to the local file system.
  *
  * <p>For convenience, the class also offers a set of functionality to select objects
- * from the current accumulated database. Examples include {@link #getChunk(byte[]) getChunk()},
- * {@link #getContent(byte[]) getContent()} and {@link #getMultiChunk(byte[]) getMultiChunk()}.
+ * from the current accumulated database. Examples include {@link #getChunk(ChunkChecksum) getChunk()},
+ * {@link #getContent(FileChecksum) getContent()} and {@link #getMultiChunk(MultiChunkId) getMultiChunk()}.
  *
  * <p>To allow this convenience, a few caches are kept in memory, and updated whenever a
  * database version is added or removed.
  *
  * @see DatabaseVersion
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class MemoryDatabase {
 	private List<DatabaseVersion> databaseVersions;

--- a/syncany-lib/src/main/java/org/syncany/database/MultiChunkEntry.java
+++ b/syncany-lib/src/main/java/org/syncany/database/MultiChunkEntry.java
@@ -30,7 +30,7 @@ import org.syncany.database.ChunkEntry.ChunkChecksum;
  * <p>A multichunk is identified by a unique identifier (random, not a checksum),
  * and contains references to {@link ChunkEntry}s.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class MultiChunkEntry {
 	private static final byte MULTICHUNK_ID_LENGTH = 20;

--- a/syncany-lib/src/main/java/org/syncany/database/ObjectId.java
+++ b/syncany-lib/src/main/java/org/syncany/database/ObjectId.java
@@ -27,7 +27,7 @@ import org.syncany.util.StringUtil;
  * As of now, it uses a byte array internally, but could also use different
  * more memory-preserving methods (such as two longs).  
  * 
- * @author Fabrice Rossi <fabrice.rossi@apiacoa.org>
+ * @author Fabrice Rossi (fabrice.rossi@apiacoa.org)
  */
 public abstract class ObjectId {
 	private static SecureRandom secureRng = new SecureRandom();

--- a/syncany-lib/src/main/java/org/syncany/database/PartialFileHistory.java
+++ b/syncany-lib/src/main/java/org/syncany/database/PartialFileHistory.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import java.util.TreeMap;
 
 /**
- * A <tt>PartialFileHistory</tt> represents a single file in a repository over a
+ * A <code>PartialFileHistory</code> represents a single file in a repository over a
  * certain period of time/versions. Whenever a file is updated or deleted, a new
  * {@link FileVersion} is added to the file history.
  *
@@ -34,7 +34,7 @@ import java.util.TreeMap;
  * history.
  *
  * @see FileVersion
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  * @author Fabrice Rossi
  */
 public class PartialFileHistory {
@@ -89,12 +89,12 @@ public class PartialFileHistory {
 
 	/**
 	 * Returns the last file version in this instance of the partial file history,
-	 * or <tt>null</tt> if there are no file versions.
+	 * or <code>null</code> if there are no file versions.
 	 *
 	 * <p>Note that this method does not necessarily return the actual overall
 	 * last file version, only the last of this object instance.
 	 *
-	 * @return Returns the last file version, or <tt>null</tt>
+	 * @return Returns the last file version, or <code>null</code>
 	 */
 	public FileVersion getLastVersion() {
 		if (versions.isEmpty()) {
@@ -112,7 +112,7 @@ public class PartialFileHistory {
 	 * the given file version.
 	 *
 	 * @param fileVersion File version to be added to the file history
-	 * @throws IllegalArgumentException If fileVersion or its version number is <tt>null</tt>
+	 * @throws IllegalArgumentException If fileVersion or its version number is <code>null</code>
 	 */
 	public void addFileVersion(FileVersion fileVersion) {
 		if (fileVersion == null || fileVersion.getVersion() == null) {

--- a/syncany-lib/src/main/java/org/syncany/database/SqlDatabase.java
+++ b/syncany-lib/src/main/java/org/syncany/database/SqlDatabase.java
@@ -58,7 +58,7 @@ import org.syncany.plugins.transfer.files.DatabaseRemoteFile;
  * @see FileHistorySqlDao
  * @see MultiChunkSqlDao
  * @see DatabaseVersionSqlDao
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class SqlDatabase {
 	protected static final Logger logger = Logger.getLogger(SqlDatabase.class.getSimpleName());

--- a/syncany-lib/src/main/java/org/syncany/database/VectorClock.java
+++ b/syncany-lib/src/main/java/org/syncany/database/VectorClock.java
@@ -37,7 +37,7 @@ import java.util.regex.Pattern;
  *
  * @author Frits de Nijs
  * @author Peter Dijkshoorn
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class VectorClock extends TreeMap<String, Long> {
 	private static final long serialVersionUID = 109876543L;	
@@ -80,7 +80,7 @@ public class VectorClock extends TreeMap<String, Long> {
 	 * Set the component of a unit.
 	 *
 	 * @param unit The identifier of the vector element being set
-	 * @value value The new value of the unit being set
+	 * @param value The new value of the unit being set
 	 */
 	public void setClock(String unit, long value) {
 		validateUnitName(unit);
@@ -91,7 +91,7 @@ public class VectorClock extends TreeMap<String, Long> {
 	 * Retrieve the unit's value
 	 *
 	 * @param unit The identifier of the vector element being retrieved
-	 * @return Returns the value of the unit (if existent), or <tt>null</tt> if it does not exist
+	 * @return Returns the value of the unit (if existent), or <code>null</code> if it does not exist
 	 */
 	public Long getClock(String unit) {
 		return get(unit);
@@ -177,8 +177,8 @@ public class VectorClock extends TreeMap<String, Long> {
 	 * VectorClock compare operation. Returns one of four possible values
 	 * indicating how clock one relates to clock two:
 	 *
-	 * VectorComparison.GREATER If One > Two. VectorComparison.EQUAL If One =
-	 * Two. VectorComparison.SMALLER If One < Two. VectorComparison.SIMULTANEOUS
+	 * VectorComparison.GREATER If One &gt; Two. VectorComparison.EQUAL If One =
+	 * Two. VectorComparison.SMALLER If One &lt; Two. VectorComparison.SIMULTANEOUS
 	 * If One != Two.
 	 *
 	 * @param clock1 First Clock being compared.

--- a/syncany-lib/src/main/java/org/syncany/database/dao/AbstractSqlDao.java
+++ b/syncany-lib/src/main/java/org/syncany/database/dao/AbstractSqlDao.java
@@ -29,7 +29,7 @@ import org.syncany.util.SqlRunner;
  * Small helper class to implement common tasks for the inheriting 
  * SQL data access objects.
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public abstract class AbstractSqlDao {
 	protected Connection connection;

--- a/syncany-lib/src/main/java/org/syncany/database/dao/ApplicationSqlDao.java
+++ b/syncany-lib/src/main/java/org/syncany/database/dao/ApplicationSqlDao.java
@@ -33,7 +33,7 @@ import org.syncany.plugins.transfer.files.DatabaseRemoteFile;
  * The application data access object (DAO) writes and queries the SQL database for
  * general information about the application.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class ApplicationSqlDao extends AbstractSqlDao {
 	protected static final Logger logger = Logger.getLogger(ApplicationSqlDao.class.getSimpleName());
@@ -137,7 +137,7 @@ public class ApplicationSqlDao extends AbstractSqlDao {
 	 * Shuts down the HSQL database, i.e. persists all data, closes all connections
 	 * and unlocks the database for other processes.
 	 *
-	 * <p>The command sends the <b><tt>SHUTDOWN</tt></b> SQL command.
+	 * <p>The command sends the <b><code>SHUTDOWN</code></b> SQL command.
 	 */
 	public void shutdown() {
 		try {

--- a/syncany-lib/src/main/java/org/syncany/database/dao/ChunkSqlDao.java
+++ b/syncany-lib/src/main/java/org/syncany/database/dao/ChunkSqlDao.java
@@ -34,7 +34,7 @@ import org.syncany.database.VectorClock;
  * on {@link ChunkEntry}s. It translates the relational data in the "chunk" table to
  * Java objects.
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class ChunkSqlDao extends AbstractSqlDao {
 	private Map<ChunkChecksum, ChunkEntry> chunkCache;
@@ -45,7 +45,7 @@ public class ChunkSqlDao extends AbstractSqlDao {
 	}
 
 	/**
-	 * Writes a list of {@link ChunkEntry}s to the database using <tt>INSERT</tt>s and the given connection.
+	 * Writes a list of {@link ChunkEntry}s to the database using <code>INSERT</code>s and the given connection.
 	 * 
 	 * <p><b>Note:</b> This method executes, but <b>does not commit</b> the query.
 	 * 
@@ -96,11 +96,11 @@ public class ChunkSqlDao extends AbstractSqlDao {
 	 * <p>Note: When first called, this method loads the <b>chunk cache</b> and keeps
 	 * this cache until it is cleared explicitly with {@link #clearCache()}. 
 	 * 
-	 * <p>Also note that this method will return <tt>null</tt> if the chunk has been
+	 * <p>Also note that this method will return <code>null</code> if the chunk has been
 	 * added after the cache has been filled. 
 	 * 
 	 * @param chunkChecksum Chunk checksum of the chunk to be selected
-	 * @return Returns the chunk entry, or <tt>null</tt> if the chunk does not exist.
+	 * @return Returns the chunk entry, or <code>null</code> if the chunk does not exist.
 	 */	
 	public synchronized ChunkEntry getChunk(ChunkChecksum chunkChecksum) {
 		if (chunkCache == null) {

--- a/syncany-lib/src/main/java/org/syncany/database/dao/DatabaseVersionSqlDao.java
+++ b/syncany-lib/src/main/java/org/syncany/database/dao/DatabaseVersionSqlDao.java
@@ -57,7 +57,7 @@ import org.syncany.operations.down.DatabaseBranch;
  * @see FileVersionSqlDao
  * @see FileHistorySqlDao
  * @see MultiChunkSqlDao
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class DatabaseVersionSqlDao extends AbstractSqlDao {
 	protected static final Logger logger = Logger.getLogger(DatabaseVersionSqlDao.class.getSimpleName());

--- a/syncany-lib/src/main/java/org/syncany/database/dao/DatabaseXmlParseHandler.java
+++ b/syncany-lib/src/main/java/org/syncany/database/dao/DatabaseXmlParseHandler.java
@@ -53,7 +53,7 @@ import org.xml.sax.helpers.DefaultHandler;
  * types (DEFAULT or PURGE).
  *  
  * @see DatabaseXmlSerializer
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class DatabaseXmlParseHandler extends DefaultHandler {
 	private static final Logger logger = Logger.getLogger(DatabaseXmlParseHandler.class.getSimpleName());

--- a/syncany-lib/src/main/java/org/syncany/database/dao/DatabaseXmlSerializer.java
+++ b/syncany-lib/src/main/java/org/syncany/database/dao/DatabaseXmlSerializer.java
@@ -43,15 +43,15 @@ import org.syncany.database.VectorClock;
  * XML-based file format, using a {@link Transformer} to compress/encrypt the file 
  * before writing, and to decompress/decrypt it before reading.
  * 
- * <p>The class offers a variety of <tt>save()</tt> to serialize and store a memory
- * database to a file, and several <tt>load()</tt> methods to load them from disk.
+ * <p>The class offers a variety of <code>save()</code> to serialize and store a memory
+ * database to a file, and several <code>load()</code> methods to load them from disk.
  * 
  * <p>It uses a {@link DatabaseXmlWriter} to write XML files to disk and 
  * {@link DatabaseXmlParseHandler} to parse them while reading. 
  * 
  * @see DatabaseXmlParseHandler
  * @see DatabaseXmlWriter
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class DatabaseXmlSerializer {
 	private static final Logger logger = Logger.getLogger(DatabaseXmlSerializer.class.getSimpleName());

--- a/syncany-lib/src/main/java/org/syncany/database/dao/DatabaseXmlWriter.java
+++ b/syncany-lib/src/main/java/org/syncany/database/dao/DatabaseXmlWriter.java
@@ -56,7 +56,7 @@ import org.syncany.util.StringUtil;
  * {@link FileContent}, {@link Chunk} and {@link MultiChunk}.
  * 
  * @see DatabaseXmlSerializer
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class DatabaseXmlWriter {
 	private static final Logger logger = Logger.getLogger(DatabaseXmlWriter.class.getSimpleName());

--- a/syncany-lib/src/main/java/org/syncany/database/dao/FileContentSqlDao.java
+++ b/syncany-lib/src/main/java/org/syncany/database/dao/FileContentSqlDao.java
@@ -35,7 +35,7 @@ import org.syncany.database.VectorClock;
  * on {@link FileContent}s. It translates the relational data in the <i>filecontent</i> table to
  * Java objects.
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class FileContentSqlDao extends AbstractSqlDao {
 	public FileContentSqlDao(Connection connection) {
@@ -43,7 +43,7 @@ public class FileContentSqlDao extends AbstractSqlDao {
 	}
 
 	/**
-	 * Writes a list of {@link FileContent}s to the database using <tt>INSERT</tt>s and the given connection.
+	 * Writes a list of {@link FileContent}s to the database using <code>INSERT</code>s and the given connection.
 	 * It fills two tables, the <i>filecontent</i> table ({@link FileContent}) and the <i>filecontent_chunk</i> 
 	 * table ({@link ChunkChecksum}).
 	 * 
@@ -126,8 +126,8 @@ public class FileContentSqlDao extends AbstractSqlDao {
 	 * corresponding chunk references (list of {@link ChunkChecksum}). 
 	 * 
 	 * @param fileChecksum {@link FileContent}-identifying file checksum
-	 * @param includeChunkChecksums If <tt>true</tt>, the resulting {@link FileContent} will contain its chunk references  
-	 * @return Returns a {@link FileContent} either with or without chunk references, or <tt>null</tt> if it does not exist. 
+	 * @param includeChunkChecksums If <code>true</code>, the resulting {@link FileContent} will contain its chunk references
+	 * @return Returns a {@link FileContent} either with or without chunk references, or <code>null</code> if it does not exist.
 	 */
 	public FileContent getFileContent(FileChecksum fileChecksum, boolean includeChunkChecksums) {
 		if (fileChecksum == null) {

--- a/syncany-lib/src/main/java/org/syncany/database/dao/FileHistorySqlDao.java
+++ b/syncany-lib/src/main/java/org/syncany/database/dao/FileHistorySqlDao.java
@@ -42,7 +42,7 @@ import com.google.common.collect.Lists;
  * The file history DAO queries and modifies the <i>filehistory</i> in
  * the SQL database. This table corresponds to the Java object {@link PartialFileHistory}.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class FileHistorySqlDao extends AbstractSqlDao {
 	private FileVersionSqlDao fileVersionDao;
@@ -53,7 +53,7 @@ public class FileHistorySqlDao extends AbstractSqlDao {
 	}
 
 	/**
-	 * Writes a list of {@link PartialFileHistory}s to the database table <i>filehistory</i> using <tt>INSERT</tt>s
+	 * Writes a list of {@link PartialFileHistory}s to the database table <i>filehistory</i> using <code>INSERT</code>s
 	 * and the given connection. In addition, this method also writes the corresponding {@link FileVersion}s of
 	 * each file history to the database using
 	 * {@link FileVersionSqlDao#writeFileVersions(Connection, FileHistoryId, long, Collection) FileVersionSqlDao#writeFileVersions}.

--- a/syncany-lib/src/main/java/org/syncany/database/dao/FileVersionSqlDao.java
+++ b/syncany-lib/src/main/java/org/syncany/database/dao/FileVersionSqlDao.java
@@ -49,7 +49,7 @@ import com.google.common.collect.ImmutableMap;
  * The file version DAO queries and modifies the <i>fileversion</i> in
  * the SQL database. This table corresponds to the Java object {@link FileVersion}.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class FileVersionSqlDao extends AbstractSqlDao {
 	private static final Logger logger = Logger.getLogger(FileVersionSqlDao.class.getSimpleName());	
@@ -68,7 +68,7 @@ public class FileVersionSqlDao extends AbstractSqlDao {
 	}
 
 	/**
-	 * Writes a list of {@link FileVersion} to the database table <i>fileversion</i> using <tt>INSERT</tt>s
+	 * Writes a list of {@link FileVersion} to the database table <i>fileversion</i> using <code>INSERT</code>s
 	 * and the given connection.
 	 *
 	 * <p><b>Note:</b> This method executes, but <b>does not commit</b> the queries.
@@ -109,7 +109,7 @@ public class FileVersionSqlDao extends AbstractSqlDao {
 
 	/**
 	 * Removes {@link FileVersion}s from the database table <i>fileversion</i> for which the
-	 * the corresponding database is marked <tt>DIRTY</tt>.
+	 * the corresponding database is marked <code>DIRTY</code>.
 	 *
 	 * <p><b>Note:</b> This method executes, but does not commit the query.
 	 *

--- a/syncany-lib/src/main/java/org/syncany/database/dao/MultiChunkSqlDao.java
+++ b/syncany-lib/src/main/java/org/syncany/database/dao/MultiChunkSqlDao.java
@@ -40,10 +40,10 @@ import org.syncany.database.VectorClock;
 
 /**
  * The multi-chunk data access object (DAO) queries and modifies the <i>multichunk</i> and
- * <i>multichunk_chunk</t> table in the SQL database. These tables correspond to the Java
+ * <i>multichunk_chunk</i> table in the SQL database. These tables correspond to the Java
  * object {@link MultiChunk}.
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class MultiChunkSqlDao extends AbstractSqlDao {
 	public MultiChunkSqlDao(Connection connection) {

--- a/syncany-lib/src/main/java/org/syncany/operations/AbstractTransferOperation.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/AbstractTransferOperation.java
@@ -45,7 +45,7 @@ import org.syncany.plugins.transfer.files.DatabaseRemoteFile;
  * <p>This abstract class offers convenience methods to handle {@link ActionRemoteFile} as well
  * as to handle the connection and local cache.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public abstract class AbstractTransferOperation extends Operation {
 	private static final Logger logger = Logger.getLogger(AbstractTransferOperation.class.getSimpleName());
@@ -128,7 +128,7 @@ public abstract class AbstractTransferOperation extends Operation {
 						logger.log(Level.INFO, "- Action file from other client, but allowed operation; not marking running; " + actionRemoteFile);
 					}
 					else {
-						logger.log(Level.INFO, "- Action file from other client; --> marking operations running (!); " + actionRemoteFile);
+						logger.log(Level.INFO, "- Action file from other client; --&gt; marking operations running (!); " + actionRemoteFile);
 						otherRemoteOperationsRunning = true;
 					}
 				}

--- a/syncany-lib/src/main/java/org/syncany/operations/AbstractTransferOperation.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/AbstractTransferOperation.java
@@ -128,7 +128,7 @@ public abstract class AbstractTransferOperation extends Operation {
 						logger.log(Level.INFO, "- Action file from other client, but allowed operation; not marking running; " + actionRemoteFile);
 					}
 					else {
-						logger.log(Level.INFO, "- Action file from other client; --&gt; marking operations running (!); " + actionRemoteFile);
+						logger.log(Level.INFO, "- Action file from other client; --> marking operations running (!); " + actionRemoteFile);
 						otherRemoteOperationsRunning = true;
 					}
 				}

--- a/syncany-lib/src/main/java/org/syncany/operations/ActionFileHandler.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/ActionFileHandler.java
@@ -43,7 +43,7 @@ import org.syncany.plugins.transfer.files.ActionRemoteFile;
  * every {@link #ACTION_RENEWAL_INTERVAL} milliseconds. The {@link #finish()} method stops this timer.
  * 
  * @see CleanupOperation
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class ActionFileHandler {	
 	private static final Logger logger = Logger.getLogger(ActionFileHandler.class.getSimpleName());

--- a/syncany-lib/src/main/java/org/syncany/operations/Assembler.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/Assembler.java
@@ -48,7 +48,7 @@ import org.syncany.util.StringUtil;
  * <p>It uses the local {@link SqlDatabase} and an optional {@link MemoryDatabase}
  * to perform file checksum and chunk checksum lookups.   
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class Assembler {
 	private static final Logger logger = Logger.getLogger(Assembler.class.getSimpleName());

--- a/syncany-lib/src/main/java/org/syncany/operations/ChangeSet.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/ChangeSet.java
@@ -29,7 +29,7 @@ import org.simpleframework.xml.ElementList;
  * <p>It contains several lists, indicating new, changed, deleted and unchanged files.
  * File paths are stored relative to the root Syncany directory.
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class ChangeSet {
 	@ElementList(name = "changedFiles", entry = "file", required = false)
@@ -52,7 +52,7 @@ public class ChangeSet {
 	}
 	
 	/**
-	 * Returns <tt>true</tt> if files have been added, changed or
+	 * Returns <code>true</code> if files have been added, changed or
 	 * deleted by checking the size of {@link #getNewFiles()}, {@link #getChangedFiles()}
 	 * and {@link #getDeletedFiles()}.
 	 */

--- a/syncany-lib/src/main/java/org/syncany/operations/Downloader.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/Downloader.java
@@ -40,7 +40,7 @@ import org.syncany.plugins.transfer.files.MultichunkRemoteFile;
  * The downloader uses a {@link TransferManager} to download a given set of multichunks,
  * decrypt them and store them in the local cache folder. 
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class Downloader {
 	private static final Logger logger = Logger.getLogger(Downloader.class.getSimpleName());

--- a/syncany-lib/src/main/java/org/syncany/operations/Operation.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/Operation.java
@@ -31,7 +31,7 @@ import org.syncany.config.Config;
  *  
  * @see OperationOptions
  * @see OperationResult
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public abstract class Operation {
 	protected Config config;

--- a/syncany-lib/src/main/java/org/syncany/operations/OperationOptions.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/OperationOptions.java
@@ -27,7 +27,7 @@ import org.simpleframework.xml.Root;
  * 
  * @see Operation
  * @see OperationResult
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 @Root(strict = false)
 public interface OperationOptions {

--- a/syncany-lib/src/main/java/org/syncany/operations/OperationResult.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/OperationResult.java
@@ -27,7 +27,7 @@ import org.simpleframework.xml.Root;
  * 
  * @see Operation
  * @see OperationOptions
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 @Root(strict = false)
 public interface OperationResult {

--- a/syncany-lib/src/main/java/org/syncany/operations/cleanup/CleanupOperation.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/cleanup/CleanupOperation.java
@@ -80,20 +80,20 @@ import org.syncany.plugins.transfer.files.RemoteFile;
  *
  * <p>High level strategy:
  * <ul>
- *    <ol>Lock repo and start thread that renews the lock every X seconds</ol>
- *    <ol>Find old versions / contents / ... from database</ol>
- *    <ol>Delete these versions and contents locally</ol>
- *    <ol>Delete all remote metadata</ol>
- *    <ol>Obtain consistent database files from local database</ol>
- *    <ol>Upload new database files to repo</ol>
- *    <ol>Remotely delete unused multichunks</ol>
- *    <ol>Stop lock renewal thread and unlock repo</ol>
+ *    <li>Lock repo and start thread that renews the lock every X seconds</li>
+ *    <li>Find old versions / contents / ... from database</li>
+ *    <li>Delete these versions and contents locally</li>
+ *    <li>Delete all remote metadata</li>
+ *    <li>Obtain consistent database files from local database</li>
+ *    <li>Upload new database files to repo</li>
+ *    <li>Remotely delete unused multichunks</li>
+ *    <li>Stop lock renewal thread and unlock repo</li>
  * </ul>
  *
  * <p><b>Important issues:</b>
  * All remote operations MUST check if the lock has been recently renewed. If it hasn't, the connection has been lost.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class CleanupOperation extends AbstractTransferOperation {
 	private static final Logger logger = Logger.getLogger(CleanupOperation.class.getSimpleName());

--- a/syncany-lib/src/main/java/org/syncany/operations/daemon/ControlServer.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/daemon/ControlServer.java
@@ -40,7 +40,7 @@ import org.syncany.config.UserConfig;
  * fork a new thread. It <b>blocks</b> and waits for commands until 
  * <b>shutdown</b> is received.
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class ControlServer implements TailerListener {	
 	private static final Logger logger = Logger.getLogger(ControlServer.class.getSimpleName());

--- a/syncany-lib/src/main/java/org/syncany/operations/daemon/DaemonOperation.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/daemon/DaemonOperation.java
@@ -56,18 +56,18 @@ import com.google.common.eventbus.Subscribe;
  * 
  * <ul>
  *  <li>The {@link WatchServer} starts a {@link WatchOperation} for every 
- *      folder registered in the <tt>daemon.xml</tt> file. It can be reloaded via
- *      the <tt>syd reload</tt> command.</li>
+ *      folder registered in the <code>daemon.xml</code> file. It can be reloaded via
+ *      the <code>syd reload</code> command.</li>
  *  <li>The {@link WebServer} starts a websocket and allows clients 
  *      (e.g. GUI, Web) to control the daemon (if authenticated). 
  *      TODO [medium] This is not yet implemented!</li>
  *  <li>The {@link ControlServer} creates and watches the daemon control file
- *      which allows the <tt>syd</tt> shell/batch script to write reload/shutdown
+ *      which allows the <code>syd</code> shell/batch script to write reload/shutdown
  *      commands.</li>  
  * </ul>
  * 
- * @author Vincent Wiencek <vwiencek@gmail.com>
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Vincent Wiencek (vwiencek@gmail.com)
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  * @author Pim Otte 
  */
 public class DaemonOperation extends Operation {	

--- a/syncany-lib/src/main/java/org/syncany/operations/daemon/EventUserInteractionListener.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/daemon/EventUserInteractionListener.java
@@ -36,7 +36,7 @@ import com.google.common.eventbus.Subscribe;
  * thread to sleep via {@link #wait()}, and waking it up via {@link #notify()}.  
  * 
  * @see UserInteractionListener
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class EventUserInteractionListener implements UserInteractionListener {
 	private static final Logger logger = Logger.getLogger(EventUserInteractionListener.class.getSimpleName());

--- a/syncany-lib/src/main/java/org/syncany/operations/daemon/ServiceAlreadyStartedException.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/daemon/ServiceAlreadyStartedException.java
@@ -18,7 +18,7 @@
 package org.syncany.operations.daemon;
 
 /** 
- * @author Vincent Wiencek <vwiencek@gmail.com>
+ * @author Vincent Wiencek (vwiencek@gmail.com)
  */
 public class ServiceAlreadyStartedException extends Exception {
 	private static final long serialVersionUID = -4655279609105005191L;

--- a/syncany-lib/src/main/java/org/syncany/operations/daemon/WatchRunner.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/daemon/WatchRunner.java
@@ -42,7 +42,7 @@ import com.google.common.eventbus.Subscribe;
  * underlying thred can be started using the {@link #start()} method, and stopped
  * gracefully using {@link #stop()}.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class WatchRunner {
 	private static final Logger logger = Logger.getLogger(WatchRunner.class.getSimpleName());

--- a/syncany-lib/src/main/java/org/syncany/operations/daemon/WatchServer.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/daemon/WatchServer.java
@@ -53,11 +53,11 @@ import com.google.common.eventbus.Subscribe;
 
 /**
  * The watch server can manage many different {@link WatchOperation}s. When started
- * with {@link #start()} or {@link #reload()}, it first reads the daemon configuration file
+ * with {@link #start(DaemonConfigTO)} or {@link #reload(DaemonConfigTO)}, it first reads the daemon configuration file
  * and then runs new threads for each configured Syncany folder. Invalid or non-existing folders
  * are ignored.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class WatchServer {
 	private static final Logger logger = Logger.getLogger(WatchServer.class.getSimpleName());

--- a/syncany-lib/src/main/java/org/syncany/operations/daemon/WebServer.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/daemon/WebServer.java
@@ -83,7 +83,7 @@ import io.undertow.websockets.core.WebSockets;
  * as well as a mechanism to run a web interface by implementing a
  * {@link WebInterfacePlugin}.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class WebServer {
 	public static final String API_ENDPOINT_WS_XML = "/api/ws/xml";

--- a/syncany-lib/src/main/java/org/syncany/operations/daemon/handlers/InternalRestHandler.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/daemon/handlers/InternalRestHandler.java
@@ -41,7 +41,7 @@ import io.undertow.server.HttpServerExchange;
 /**
  * InteralRestHandler handles the REST requests sent to the daemon.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class InternalRestHandler implements HttpHandler {
 	private static final Logger logger = Logger.getLogger(InternalRestHandler.class.getSimpleName());

--- a/syncany-lib/src/main/java/org/syncany/operations/daemon/handlers/InternalWebInterfaceHandler.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/daemon/handlers/InternalWebInterfaceHandler.java
@@ -34,7 +34,7 @@ import org.syncany.util.StringUtil.StringJoinListener;
  * InternalWebInterfaceHandler is responsible for handling requests 
  * to the web interface.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class InternalWebInterfaceHandler implements HttpHandler {
 	private static final Logger logger = Logger.getLogger(InternalWebInterfaceHandler.class.getSimpleName());
@@ -83,7 +83,7 @@ public class InternalWebInterfaceHandler implements HttpHandler {
 		exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "text/html");
 		
 		if (webInterfacePlugins.size() == 0) {
-			String responseMessage = "No web interface installed.<br />Use <tt>sy plugin install simpleweb --snapshot</tt> "
+			String responseMessage = "No web interface installed.<br>Use <code>sy plugin install simpleweb --snapshot</code> "
 					+ "to install a web interface, then restart the daemon.";
 			
 			exchange.getResponseSender().send(responseMessage);
@@ -96,7 +96,7 @@ public class InternalWebInterfaceHandler implements HttpHandler {
 			});
 			
 			String responseMessage = "Only one web interface can be installed, but " + webInterfacePlugins.size() + " plugins found: "
-					+ webInterfacePluginsList + "<br />Use <tt>sy plugin remove &lt;pluginId&gt;</tt> to remove plugins, then restart the daemon.";
+					+ webInterfacePluginsList + "<br>Use <code>sy plugin remove &lt;pluginId&gt;</code> to remove plugins, then restart the daemon.";
 
 			exchange.getResponseSender().send(responseMessage);
 		}

--- a/syncany-lib/src/main/java/org/syncany/operations/daemon/handlers/InternalWebSocketHandler.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/daemon/handlers/InternalWebSocketHandler.java
@@ -47,7 +47,7 @@ import io.undertow.websockets.spi.WebSocketHttpExchange;
  * InternalWebSocketHandler handles the web socket requests
  * sent to the daemon.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class InternalWebSocketHandler implements WebSocketConnectionCallback {
 	private static final Logger logger = Logger.getLogger(InternalWebSocketHandler.class.getSimpleName());

--- a/syncany-lib/src/main/java/org/syncany/operations/daemon/messages/api/Event.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/daemon/messages/api/Event.java
@@ -25,7 +25,7 @@ package org.syncany.operations.daemon.messages.api;
  * <p>Certain events may be broadcasted to external subscribers via
  * web socket or other technologies.
  *  
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public abstract class Event extends Message {
 	// Marker

--- a/syncany-lib/src/main/java/org/syncany/operations/daemon/messages/api/ExternalEvent.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/daemon/messages/api/ExternalEvent.java
@@ -26,7 +26,7 @@ import org.simpleframework.xml.Root;
  * <p>In particular, they might be broadcasted to external subscribers,
  * such as GUIs connected via WS.
  *  
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 @Root
 public abstract class ExternalEvent extends Event {

--- a/syncany-lib/src/main/java/org/syncany/operations/daemon/messages/api/InternalEvent.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/daemon/messages/api/InternalEvent.java
@@ -25,7 +25,7 @@ import org.simpleframework.xml.Root;
  * <p>In particular, they are not to be broadcasted to external subscribers,
  * such as GUIs connected via WS, but only to the local event bus.
  *  
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 @Root
 public abstract class InternalEvent extends Event {

--- a/syncany-lib/src/main/java/org/syncany/operations/daemon/messages/api/JsonMessageFactory.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/daemon/messages/api/JsonMessageFactory.java
@@ -27,7 +27,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
 /**
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Christian Roth (christian.roth@port17.de)
  */
 public abstract class JsonMessageFactory extends MessageFactory {
 	private static final Gson SERIALIZER = new Gson();

--- a/syncany-lib/src/main/java/org/syncany/operations/daemon/messages/api/Message.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/daemon/messages/api/Message.java
@@ -25,7 +25,7 @@ import org.simpleframework.xml.Root;
  * class. Messages can be serialized/deserialized using the
  * {@link MessageFactory}. 
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 @Root(strict = false)
 public abstract class Message {

--- a/syncany-lib/src/main/java/org/syncany/operations/daemon/messages/api/MessageFactory.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/daemon/messages/api/MessageFactory.java
@@ -26,7 +26,7 @@ import org.syncany.util.StringUtil;
  * The message factory serializes and deserializes messages sent to
  * or from the daemon via the REST/WS API.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public abstract class MessageFactory {
 	protected static final Logger logger = Logger.getLogger(MessageFactory.class.getSimpleName());

--- a/syncany-lib/src/main/java/org/syncany/operations/daemon/messages/api/XmlMessageFactory.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/daemon/messages/api/XmlMessageFactory.java
@@ -38,7 +38,7 @@ import org.syncany.database.VectorClock;
  * XML (via SimpleXML).  
  * 
  * @see <a href="http://simple.sourceforge.net/">Simple framework</a>
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Christian Roth (christian.roth@port17.de)
  */
 public abstract class XmlMessageFactory extends MessageFactory {
 	private static final Pattern MESSAGE_TYPE_PATTERN = Pattern.compile("\\<([^\\/>\\s]+)");

--- a/syncany-lib/src/main/java/org/syncany/operations/down/ApplyChangesOperation.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/down/ApplyChangesOperation.java
@@ -48,13 +48,13 @@ import org.syncany.plugins.transfer.TransferManager;
  *  <li>Determine whether the local branch needs to be updated (new database versions); if so, determine
  *      local {@link FileSystemAction}s</li>
  *  <li>Determine, download and decrypt required multi chunks from remote storage from file actions
- *      (implemented in {@link #determineMultiChunksToDownload(FileVersion, MemoryDatabase, MemoryDatabase) determineMultiChunksToDownload()},
- *      and {@link #downloadAndDecryptMultiChunks(Set) downloadAndDecryptMultiChunks()})</li>
+ *      (implemented in {@link #determineMultiChunksToDownload(FileVersion, MemoryDatabase) determineMultiChunksToDownload()},
+ *      and {@link Downloader#downloadAndDecryptMultiChunks(Set) downloadAndDecryptMultiChunks()})</li>
  *  <li>Apply file system actions locally, creating conflict files where necessary if local file does
  *      not match the expected file (implemented in {@link #applyFileSystemActions(List) applyFileSystemActions()} </li>
  * </ul>
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class ApplyChangesOperation extends Operation {
 	private static final Logger logger = Logger.getLogger(DownOperation.class.getSimpleName());

--- a/syncany-lib/src/main/java/org/syncany/operations/down/DatabaseBranch.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/down/DatabaseBranch.java
@@ -32,7 +32,7 @@ import org.syncany.database.DatabaseVersionHeader;
  * <p>Branches are used mainly in the {@link DatabaseReconciliator} to compare database
  * versions and reconcile conflicts.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class DatabaseBranch {
 	private ArrayList<DatabaseVersionHeader> branch;

--- a/syncany-lib/src/main/java/org/syncany/operations/down/DatabaseBranches.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/down/DatabaseBranches.java
@@ -28,7 +28,7 @@ import java.util.TreeMap;
  * <p>The class is mainly used by the {@link DatabaseReconciliator} when comparing
  * and reconciling changes between the clients' database branches. 
  *    
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class DatabaseBranches {
 	private TreeMap<String, DatabaseBranch> branches;

--- a/syncany-lib/src/main/java/org/syncany/operations/down/DatabaseFileReader.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/down/DatabaseFileReader.java
@@ -64,7 +64,7 @@ public class DatabaseFileReader implements Iterator<MemoryDatabase> {
 	 * <p>Because database files can contain multiple {@link DatabaseVersion}s per client, a range for which
 	 * to load the database versions must be determined.
 	 *
-	 * <p><b>Example 1:</b><br />
+	 * <p><b>Example 1:</b><br>
 	 * <pre>
 	 *  db-A-0001   (A1)     Already known             Not loaded
 	 *  db-A-0005   (A2)     Already known             Not loaded
@@ -77,7 +77,7 @@ public class DatabaseFileReader implements Iterator<MemoryDatabase> {
 	 *
 	 * <p>In example 1, only (A4)-(A5) must be loaded from db-A-0005, and not all four database versions.
 	 *
-	 * <p><b>Other example:</b><br />
+	 * <p><b>Other example:</b><br>
 	 * <pre>
 	 *  db-A-0005   (A1)     Part of winner's branch   Loaded
 	 *  db-A-0005   (A2)     Part of winner's branch   Loaded
@@ -91,8 +91,6 @@ public class DatabaseFileReader implements Iterator<MemoryDatabase> {
 	 * db-A-0005 must be processed twice; each time loading separate parts of the file. In this case:
 	 * First load (A1)-(A2) from db-A-0005, then load (A2,B1) from db-B-0001, then load (A3,B1)-(A4,B1)
 	 * from db-A-0005, and ignore (A5,B1).
-	 * @param databaseFileList
-	 * @param ignoredMostRecentPurgeVersions
 	 *
 	 * @return Returns a loaded memory database containing all metadata from the winner's branch
 	 */

--- a/syncany-lib/src/main/java/org/syncany/operations/down/DatabaseReconciliator.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/down/DatabaseReconciliator.java
@@ -53,9 +53,9 @@ import org.syncany.database.VectorClock;
  * 
  * @see DownOperation
  * @see VectorClock
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
- * @author Pim Otte <otte.pim@gmail.com>
- * @author Steffen Dangmann <steffen.dangmann@googlemail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
+ * @author Pim Otte (otte.pim@gmail.com)
+ * @author Steffen Dangmann (steffen.dangmann@googlemail.com)
  */
 public class DatabaseReconciliator {
 	private static final Logger logger = Logger.getLogger(DatabaseReconciliator.class.getSimpleName());
@@ -63,9 +63,6 @@ public class DatabaseReconciliator {
 	/**
 	 * Implements the core synchronization algorithm as described {@link DatabaseReconciliator in the class description}.
 	 * 
-	 * @param localMachineName Client name of the local machine (required for branch stitching)
-	 * @param localBranch Local branch, created from the local database
-	 * @param unknownRemoteBranches Newly downloaded unknown remote branches (incomplete branches; will be stitched)
 	 * @return Returns the branch of the winning client
 	 */
 	public Map.Entry<String, DatabaseBranch> findWinnerBranch(DatabaseBranches allBranches)
@@ -141,7 +138,7 @@ public class DatabaseReconciliator {
 	 * Iterate over this list, adding databaseversions to the winning branch if they are not simultaneous with the
 	 * winning branch up until this point. 
 	 *
-	 * <p><b>Illustration:</b><br />
+	 * <p><b>Illustration:</b><br>
 	 * Suppose the following branches exist. 
 	 * Naming: <em>created-by / vector clock / local time</em>.
 	 * 
@@ -186,7 +183,7 @@ public class DatabaseReconciliator {
 	 * 
 	 * Last version matches last version of B. Hence B wins.
 	 * 
-	 * @param allStitchedBranches All branches of all machines (including local)
+	 * @param allBranches All branches of all machines (including local)
 	 * @return Returns the name and the branch of the winning machine 
 	 */
 	private Entry<String, DatabaseBranch> findWinnersNameAndBranch(DatabaseBranches allBranches) {

--- a/syncany-lib/src/main/java/org/syncany/operations/down/DatabaseReconciliator.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/down/DatabaseReconciliator.java
@@ -62,7 +62,8 @@ public class DatabaseReconciliator {
 
 	/**
 	 * Implements the core synchronization algorithm as described {@link DatabaseReconciliator in the class description}.
-	 * 
+	 *
+	 * @param allBranches All branches of all machines (including local)
 	 * @return Returns the branch of the winning client
 	 */
 	public Map.Entry<String, DatabaseBranch> findWinnerBranch(DatabaseBranches allBranches)

--- a/syncany-lib/src/main/java/org/syncany/operations/down/DatabaseVersionHeaderComparator.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/down/DatabaseVersionHeaderComparator.java
@@ -38,7 +38,7 @@ import org.syncany.database.VectorClock.VectorClockComparison;
  * Equal and simultaneous {@link VectorClock}s result in equal {@link DatabaseVersionHeader}s. Note that in
  * this case the name of the client is not used either.
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class DatabaseVersionHeaderComparator implements Comparator<DatabaseVersionHeader> {
 	private boolean considerTime;

--- a/syncany-lib/src/main/java/org/syncany/operations/down/DownOperation.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/down/DownOperation.java
@@ -70,9 +70,9 @@ import com.google.common.collect.Sets.SetView;
  * <p>The general operation flow is as follows:
  * <ol>
  *  <li>List all database versions on the remote storage using the {@link LsRemoteOperation}
- *      (implemented in {@link #listUnknownRemoteDatabases(MemoryDatabase, TransferManager) listUnknownRemoteDatabases()}</li>
+ *      (implemented in {@link #listUnknownRemoteDatabases() listUnknownRemoteDatabases()}</li>
  *  <li>Download unknown databases using a {@link TransferManager} (if any), skip the rest down otherwise
- *      (implemented in {@link #downloadUnknownRemoteDatabases(TransferManager, List) downloadUnknownRemoteDatabases()}</li>
+ *      (implemented in {@link #downloadUnknownRemoteDatabases(List) downloadUnknownRemoteDatabases()}</li>
  *  <li>Load remote database headers (branches) and compare them to the local database to determine a winner
  *      using several methods of the {@link DatabaseReconciliator}</li>
  *  <li>Determine whether the local branch conflicts with the winner branch; if so, prune conflicting
@@ -85,7 +85,7 @@ import com.google.common.collect.Sets.SetView;
  * </ol>
  *
  * @see DatabaseReconciliator
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class DownOperation extends AbstractTransferOperation {
 	private static final Logger logger = Logger.getLogger(DownOperation.class.getSimpleName());
@@ -224,9 +224,9 @@ public class DownOperation extends AbstractTransferOperation {
 	 * Checks whether any new databases are only and whether any other conflicting
 	 * actions are running.
 	 *
-	 * <p>This method sets the result code in <tt>result</tt> according to the
-	 * checking result and returns <tt>true</tt> if the rest of the operation can
-	 * continue, <tt>false</tt> otherwise.
+	 * <p>This method sets the result code in <code>result</code> according to the
+	 * checking result and returns <code>true</code> if the rest of the operation can
+	 * continue, <code>false</code> otherwise.
 	 */
 	private boolean checkPreconditions() throws Exception {
 		// Check strategies
@@ -375,7 +375,6 @@ public class DownOperation extends AbstractTransferOperation {
 	 *
 	 * <p>The detailed algorithm is described in the {@link DatabaseReconciliator}.
 	 *
-	 * @param localBranch Local database branch (extracted from the local database)
 	 * @param allStitchedBranches The newly downloaded remote database version headers (= branches)
 	 * @return Returns the branch of the winner
 	 * @throws Exception If any kind of error occurs (...)
@@ -395,7 +394,7 @@ public class DownOperation extends AbstractTransferOperation {
 	}
 
 	/**
-	 * Marks locally conflicting database versions as <tt>DIRTY</tt> and removes remote databases that
+	 * Marks locally conflicting database versions as <code>DIRTY</code> and removes remote databases that
 	 * correspond to those database versions. This method uses the {@link DatabaseReconciliator}
 	 * to determine whether there is a local purge branch.
 	 */

--- a/syncany-lib/src/main/java/org/syncany/operations/down/FileSystemActionComparator.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/down/FileSystemActionComparator.java
@@ -118,7 +118,7 @@ public class FileSystemActionComparator  {
 				int conflictingDeleteActionIndex = getPathConflictingWithDeleteActionIndex(currentAction, fixedActions);
 				
 				if (conflictingDeleteActionIndex >= 0) {
-					logger.log(Level.INFO, "     --&gt; match, conflict ["+i+"]: "+currentAction);
+					logger.log(Level.INFO, "     --> match, conflict ["+i+"]: "+currentAction);
 					logger.log(Level.INFO, "                    with ["+conflictingDeleteActionIndex+"]: "+fixedActions.get(conflictingDeleteActionIndex));
 					
 					fixedActions.remove(i);

--- a/syncany-lib/src/main/java/org/syncany/operations/down/FileSystemActionComparator.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/down/FileSystemActionComparator.java
@@ -52,7 +52,7 @@ import org.syncany.operations.down.actions.RenameFileSystemAction;
  * - Change folder
  * 
  * 
- * TODO [medium] NewSymlinkFileSystemAction --> NewFile (has no content)
+ * TODO [medium] NewSymlinkFileSystemAction → NewFile (has no content)
  */
 public class FileSystemActionComparator  {
 	private static final Logger logger = Logger.getLogger(FileSystemActionComparator.class.getSimpleName());
@@ -91,13 +91,13 @@ public class FileSystemActionComparator  {
 	 * 
 	 * DEL  FILE     file1.jpg      
 	 * NEW  FOLDER   folder1
-	 * NEW  FILE     folder1/fileinfolder1.jpg                       < No Issue, but needs to be checked
-	 * NEW  FILE     folder2                                         <<< Issue, because folder2 is deleted below!
-	 * NEW  SYMLINK  folder1/symlinkinfolder1.jpg                    < No Issue, but needs to be checked
-	 * REN  FILE     folder2/fileinfolder2.jpg -> folder1/x2.jpg
-	 * REN  SYMLINK  folder2/symlinkinfolder2.jpg -> folder1/sym2
+	 * NEW  FILE     folder1/fileinfolder1.jpg                       ← No Issue, but needs to be checked
+	 * NEW  FILE     folder2                                         ←←← Issue, because folder2 is deleted below!
+	 * NEW  SYMLINK  folder1/symlinkinfolder1.jpg                    ← No Issue, but needs to be checked
+	 * REN  FILE     folder2/fileinfolder2.jpg → folder1/x2.jpg
+	 * REN  SYMLINK  folder2/symlinkinfolder2.jpg → folder1/sym2
 	 * DEL  FOLDER   folder2
-	 *                                                               <<< New position of "NEW FILE folder2"!
+	 *                                                               ←←← New position of "NEW FILE folder2"!
 	 */
 	public void postCompareSort(List<FileSystemAction> actions) {
 		List<FileSystemAction> fixedActions = new ArrayList<FileSystemAction>(actions);
@@ -118,7 +118,7 @@ public class FileSystemActionComparator  {
 				int conflictingDeleteActionIndex = getPathConflictingWithDeleteActionIndex(currentAction, fixedActions);
 				
 				if (conflictingDeleteActionIndex >= 0) {
-					logger.log(Level.INFO, "     --> match, conflict ["+i+"]: "+currentAction);
+					logger.log(Level.INFO, "     --&gt; match, conflict ["+i+"]: "+currentAction);
 					logger.log(Level.INFO, "                    with ["+conflictingDeleteActionIndex+"]: "+fixedActions.get(conflictingDeleteActionIndex));
 					
 					fixedActions.remove(i);

--- a/syncany-lib/src/main/java/org/syncany/operations/down/actions/FileSystemAction.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/down/actions/FileSystemAction.java
@@ -55,7 +55,7 @@ import org.syncany.util.NormalizedPath;
  * <p>Implementations of this class treat file1 and file2 differently, depending on what
  * action they implement.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public abstract class FileSystemAction {
 	protected static final Logger logger = Logger.getLogger(FileSystemAction.class.getSimpleName());

--- a/syncany-lib/src/main/java/org/syncany/operations/init/AbstractInitOperation.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/init/AbstractInitOperation.java
@@ -45,7 +45,7 @@ import org.syncany.util.EnvironmentUtil;
  * and the {@link ConnectOperation}. Its sole purpose is to avoid duplicate code in these
  * similar operations.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public abstract class AbstractInitOperation extends Operation {
 	protected static final Logger logger = Logger.getLogger(AbstractInitOperation.class.getSimpleName());

--- a/syncany-lib/src/main/java/org/syncany/operations/init/ApplicationLink.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/init/ApplicationLink.java
@@ -63,7 +63,7 @@ import org.syncany.util.Base58;
 import com.google.common.primitives.Ints;
 
 /**
- * The application link class represents a <tt>syncany://</tt> link. It allowed creating
+ * The application link class represents a <code>syncany://</code> link. It allowed creating
  * and parsing a link. The class has two modes of operation:
  *
  * <p>To create a new application link from an existing repository, call the
@@ -75,8 +75,8 @@ import com.google.common.primitives.Ints;
  * {@link #ApplicationLink(String)} constructor and subsequently call {@link #createTransferSettings()}
  * or {@link #createTransferSettings(SaltedSecretKey)}. This method will typically be called during the 'connect' process.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
+ * @author Christian Roth (christian.roth@port17.de)
  */
 public class ApplicationLink {
 	private static final Logger logger = Logger.getLogger(ApplicationLink.class.getSimpleName());

--- a/syncany-lib/src/main/java/org/syncany/operations/init/ConnectOperation.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/init/ConnectOperation.java
@@ -59,7 +59,7 @@ import org.syncany.plugins.transfer.files.SyncanyRemoteFile;
  *       folder and the sub-structure) and copying the repo/master file to it.</li>
  * </ul>
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class ConnectOperation extends AbstractInitOperation {
 	private static final Logger logger = Logger.getLogger(ConnectOperation.class.getSimpleName());

--- a/syncany-lib/src/main/java/org/syncany/operations/init/GenlinkOperation.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/init/GenlinkOperation.java
@@ -29,7 +29,7 @@ import org.syncany.config.to.ConfigTO;
  * a repository. The operation is used by other initializing operations, e.g. connect
  * and init.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class GenlinkOperation extends AbstractInitOperation {
 	private static final Logger logger = Logger.getLogger(GenlinkOperation.class.getSimpleName());

--- a/syncany-lib/src/main/java/org/syncany/operations/init/InitOperation.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/init/InitOperation.java
@@ -53,7 +53,7 @@ import org.syncany.plugins.transfer.files.SyncanyRemoteFile;
  *       saving them locally and uploading them to the remote repository.</li>
  * </ul>
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class InitOperation extends AbstractInitOperation {
 	public static final String DEFAULT_IGNORE_FILE = "/" + InitOperation.class.getPackage().getName().replace('.', '/') + "/default.syignore";

--- a/syncany-lib/src/main/java/org/syncany/operations/ls_remote/LsRemoteOperation.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/ls_remote/LsRemoteOperation.java
@@ -43,7 +43,7 @@ import org.syncany.plugins.transfer.files.DatabaseRemoteFile;
  * uses the local list of known databases to filter already processed files. The local
  * list of known databases is loaded.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class LsRemoteOperation extends Operation {
 	private static final Logger logger = Logger.getLogger(LsRemoteOperation.class.getSimpleName());

--- a/syncany-lib/src/main/java/org/syncany/operations/plugin/PluginOperation.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/plugin/PluginOperation.java
@@ -71,22 +71,22 @@ import com.google.common.collect.Lists;
  * {@link PluginOperationAction}:
  *
  * <ul>
- * <li><tt>INSTALL</tt>: Installation means copying a file to the user plugin directory
- * as specified by {@link Client#getUserPluginLibDir()}. A plugin can be installed
+ * <li><code>INSTALL</code>: Installation means copying a file to the user plugin directory
+ * as specified by {@link UserConfig#getUserPluginLibDir()}. A plugin can be installed
  * from a local JAR file, a URL (the operation downloads a JAR file), or the
  * API host (the operation find the plugin using the 'list' action and downloads
  * the JAR file).</li>
- * <li><tt>REMOVE</tt>: Removal means deleting a JAR file from the user plugin
+ * <li><code>REMOVE</code>: Removal means deleting a JAR file from the user plugin
  * directoryThis action. This action simply finds the responsible plugin JAR
  * file and deletes it. Only JAR files inside the user plugin direcory can be
  * deleted.</li>
- * <li><tt>LIST</tt>: Listing refers to a local and a remote list. The locally installed
+ * <li><code>LIST</code>: Listing refers to a local and a remote list. The locally installed
  * plugins can be queried by {@link Plugins#list()}. These plugins' JAR files must be
  * in the application's class path. Remotely available plugins are queried through the
  * API.</li>
  * </ul>
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class PluginOperation extends Operation {
 	private static final Logger logger = Logger.getLogger(PluginOperation.class.getSimpleName());

--- a/syncany-lib/src/main/java/org/syncany/operations/status/StatusOperation.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/status/StatusOperation.java
@@ -48,7 +48,7 @@ import org.syncany.util.FileUtil;
  * database. It uses the {@link FileVersionComparator} to determine differences and returns
  * new/changed/deleted files in form of a {@link ChangeSet}.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class StatusOperation extends Operation {
 	private static final Logger logger = Logger.getLogger(StatusOperation.class.getSimpleName());

--- a/syncany-lib/src/main/java/org/syncany/operations/up/Indexer.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/up/Indexer.java
@@ -558,7 +558,7 @@ public class Indexer {
 				Collection<PartialFileHistory> fileHistoriesWithSameChecksum) {
 			PartialFileHistory lastFileHistory = null;
 
-			// Check if they do not exist anymore --&gt; assume it has moved!
+			// Check if they do not exist anymore --> assume it has moved!
 			// We choose the best fileHistory to base on as follows:
 
 			// 1. Ensure that it was modified at the same time and is the same size

--- a/syncany-lib/src/main/java/org/syncany/operations/up/Indexer.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/up/Indexer.java
@@ -67,13 +67,13 @@ import org.syncany.util.StringUtil;
  * break these files into individual chunks. By implementing the {@link DeduperListener},
  * it reacts on chunking events and creates a new database version (with the newly
  * added/changed/removed files. This functionality is entirely implemented by the
- * {@link #index(List) index()} method.
+ * index() method.
  * 
  * <p>The class uses the currently loaded {@link MemoryDatabase} as well as a potential  
  * dirty database into account. Lookups for chunks and file histories are performed 
  * on both databases.
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class Indexer {
 	private static final Logger logger = Logger.getLogger(Indexer.class.getSimpleName());
@@ -558,7 +558,7 @@ public class Indexer {
 				Collection<PartialFileHistory> fileHistoriesWithSameChecksum) {
 			PartialFileHistory lastFileHistory = null;
 
-			// Check if they do not exist anymore --> assume it has moved!
+			// Check if they do not exist anymore --&gt; assume it has moved!
 			// We choose the best fileHistory to base on as follows:
 
 			// 1. Ensure that it was modified at the same time and is the same size

--- a/syncany-lib/src/main/java/org/syncany/operations/up/UpOperation.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/up/UpOperation.java
@@ -95,7 +95,7 @@ import org.syncany.plugins.transfer.to.TransactionTO;
  * If a sequence of transactions is interrupted, all queued transactions are written to disk to be resumed later.
  * The next up operation then reads these transactions and resumes them in the same order as they were queued before the interruption.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class UpOperation extends AbstractTransferOperation {
 	private static final Logger logger = Logger.getLogger(UpOperation.class.getSimpleName());

--- a/syncany-lib/src/main/java/org/syncany/operations/update/AppInfo.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/update/AppInfo.java
@@ -30,7 +30,7 @@ import org.simpleframework.xml.Root;
  *  
  * @see <a href="http://simple.sourceforge.net/">Simple framework</a>
  * @see <a href="https://github.com/syncany/syncany-website">Syncany Website/API</a>
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 @Root(name = "appInfo", strict = false)
 public class AppInfo {

--- a/syncany-lib/src/main/java/org/syncany/operations/update/AppInfoResponse.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/update/AppInfoResponse.java
@@ -34,7 +34,7 @@ import org.simpleframework.xml.Root;
  *  
  * @see <a href="http://simple.sourceforge.net/">Simple framework</a>
  * @see <a href="https://github.com/syncany/syncany-website">Syncany Website/API</a>
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 @Root(name = "appInfoResponse")
 public class AppInfoResponse {

--- a/syncany-lib/src/main/java/org/syncany/operations/update/UpdateOperation.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/update/UpdateOperation.java
@@ -48,7 +48,7 @@ import com.github.zafarkhaja.semver.Version;
  * and a download URL.
  * 
  * @see <a href="https://github.com/syncany/syncany-website">Syncany Website/API</a>
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class UpdateOperation extends Operation {
 	private static final Logger logger = Logger.getLogger(UpdateOperation.class.getSimpleName());

--- a/syncany-lib/src/main/java/org/syncany/operations/update/UpdateOperationAction.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/update/UpdateOperationAction.java
@@ -20,7 +20,7 @@ package org.syncany.operations.update;
 /**
  * Actions contained in the {@link UpdateOperation}.
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public enum UpdateOperationAction {
 	/**

--- a/syncany-lib/src/main/java/org/syncany/operations/update/UpdateOperationOptions.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/update/UpdateOperationOptions.java
@@ -24,7 +24,7 @@ import org.syncany.operations.OperationOptions;
  * The options alter/influence the behavior of the operation.
  * 
  * @see <a href="https://github.com/syncany/syncany-website">Syncany Website/API</a>
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class UpdateOperationOptions implements OperationOptions {
 	private UpdateOperationAction action = null;

--- a/syncany-lib/src/main/java/org/syncany/operations/update/UpdateOperationResult.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/update/UpdateOperationResult.java
@@ -26,7 +26,7 @@ import org.syncany.operations.OperationResult;
  * this class will contain information about whether the operation
  * was successful, and if it was, the available application information. 
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class UpdateOperationResult implements OperationResult {
 	/**

--- a/syncany-lib/src/main/java/org/syncany/operations/watch/DefaultRecursiveWatcher.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/watch/DefaultRecursiveWatcher.java
@@ -51,7 +51,7 @@ import java.util.logging.Level;
  * to settle. It is reset whenever a new event occurs. When the timer times out,
  * an event is thrown through the {@link WatchListener}.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class DefaultRecursiveWatcher extends RecursiveWatcher {
 	private WatchService watchService;

--- a/syncany-lib/src/main/java/org/syncany/operations/watch/NotificationListener.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/watch/NotificationListener.java
@@ -37,17 +37,17 @@ import org.syncany.util.StringUtil;
  * The notification listener implements a client to the fanout, as very
  * lightweight pub/sub server originally written for SparkleShare.
  *
- * <p>Fanout implements a simple TCP-based plaintext protocol.<br />
+ * <p>Fanout implements a simple TCP-based plaintext protocol.<br>
  * It implements the following <b>commands</b>:
  * <ul>
- *  <li><tt>subcribe &lt;channel&gt;</tt></li>
- *  <li><tt>unsubscribe &lt;channel&gt;</tt></li>
- *  <li><tt>announce &lt;channel&gt; &lt;message&gt;</tt></li>
+ *  <li><code>subcribe &lt;channel&gt;</code></li>
+ *  <li><code>unsubscribe &lt;channel&gt;</code></li>
+ *  <li><code>announce &lt;channel&gt; &lt;message&gt;</code></li>
  * </ul>
  *
  * <p><b>Notifications</b> have the following format:
  * <ul>
- *  <li><tt>&lt;channel&gt;!&lt;message&gt;</tt></li>
+ *  <li><code>&lt;channel&gt;!&lt;message&gt;</code></li>
  * </ul>
  *
  * <p>The notification listener starts a thread and listens for incoming messages.
@@ -56,7 +56,7 @@ import org.syncany.util.StringUtil;
  * {@link NotificationListenerListener}.
  *
  * @see <a href="https://github.com/travisghansen/fanout/">https://github.com/travisghansen/fanout/</a> - Fanout source code by Travis G. Hansen
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class NotificationListener {
 	private static final Logger logger = Logger.getLogger(NotificationListener.class.getSimpleName());

--- a/syncany-lib/src/main/java/org/syncany/operations/watch/RecursiveWatcher.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/watch/RecursiveWatcher.java
@@ -40,7 +40,7 @@ import org.syncany.util.EnvironmentUtil;
  * in different lifecycle states: {@link #beforeStart()}, {@link #beforePollEventLoop()},
  * {@link #pollEvents()}, and {@link #afterStop()}.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public abstract class RecursiveWatcher {
 	protected static final Logger logger = Logger.getLogger(RecursiveWatcher.class.getSimpleName());

--- a/syncany-lib/src/main/java/org/syncany/operations/watch/WatchOperation.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/watch/WatchOperation.java
@@ -69,7 +69,7 @@ import org.syncany.util.StringUtil;
  * As of now, this operation never returns, because it runs in a loop. The user
  * has to manually abort the operation on the command line.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class WatchOperation extends Operation implements NotificationListenerListener, WatchListener {
 	private static final Logger logger = Logger.getLogger(WatchOperation.class.getSimpleName());

--- a/syncany-lib/src/main/java/org/syncany/operations/watch/WatchOperationOptions.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/watch/WatchOperationOptions.java
@@ -31,7 +31,7 @@ import org.syncany.operations.up.UpOperationOptions;
  * 
  * <p>The options can also be stored as XML within the daemon configuration.
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 @Root(name="watch")
 public class WatchOperationOptions implements OperationOptions {

--- a/syncany-lib/src/main/java/org/syncany/operations/watch/WatchOperationResult.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/watch/WatchOperationResult.java
@@ -25,7 +25,7 @@ import org.syncany.operations.OperationResult;
  * process and does not immediately return, the return value of this
  * operation has no value.
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class WatchOperationResult implements OperationResult {
 	// Nothing.

--- a/syncany-lib/src/main/java/org/syncany/operations/watch/WindowsRecursiveWatcher.java
+++ b/syncany-lib/src/main/java/org/syncany/operations/watch/WindowsRecursiveWatcher.java
@@ -47,7 +47,7 @@ import name.pachler.nio.file.WatchService;
  * to settle. It is reset whenever a new event occurs. When the timer times out,
  * an event is thrown through the {@link WatchListener}.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class WindowsRecursiveWatcher extends RecursiveWatcher {
 	private WatchService watchService;

--- a/syncany-lib/src/main/java/org/syncany/plugins/Plugin.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/Plugin.java
@@ -25,7 +25,7 @@ import org.syncany.plugins.transfer.TransferSettings;
 
 /**
  * A plugin can be used to store Syncany's repository files on any remote location. 
- * Implementations of the <tt>Plugin</tt> class identify a storage/transfer plugin.
+ * Implementations of the <code>Plugin</code> class identify a storage/transfer plugin.
  * 
  * <p>Using the 'id' attribute, plugins can be loaded by the {@link Plugins} class. 
  * Once a plugin is loaded, a corresponding {@link TransferSettings} object must be created and 
@@ -36,7 +36,7 @@ import org.syncany.plugins.transfer.TransferSettings;
  * Furthermore, all plugin classes must reside in a package <b>org.syncany.plugins.<i>plugin-id</i></b>,
  * where <i>plugin-id</i> is the identifier specified by {@link #getId()}. 
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public abstract class Plugin {
 	private static final String PLUGIN_PROPERTIES_NAME_KEY = "pluginName";

--- a/syncany-lib/src/main/java/org/syncany/plugins/Plugins.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/Plugins.java
@@ -41,7 +41,7 @@ import com.google.common.reflect.ClassPath.ClassInfo;
  * </ul>
  *
  * @see Plugin
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class Plugins {
 	private static final Logger logger = Logger.getLogger(Plugins.class.getSimpleName());
@@ -83,8 +83,8 @@ public class Plugins {
 	 * <p>Note: Unlike the {@link #list()} method, this method is not expected
 	 * to take long, because there is no need to read all JARs in the classpath.
 	 *
-	 * @param pluginId Identifier of the plugin, as defined by {@link Plugin#getId() the plugin ID)
-	 * @return Returns an instance of a plugin, or <tt>null</tt> if no plugin with the given identifier can be found
+	 * @param pluginId Identifier of the plugin, as defined by {@link Plugin#getId() the plugin ID}
+	 * @return Returns an instance of a plugin, or <code>null</code> if no plugin with the given identifier can be found
 	 */
 	public static Plugin get(String pluginId) {
 		if (pluginId == null) {

--- a/syncany-lib/src/main/java/org/syncany/plugins/UserInteractionListener.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/UserInteractionListener.java
@@ -22,7 +22,7 @@ package org.syncany.plugins;
  * to request feedback from the user -- either in form of a confirmation
  * or a password. The methods implemented by this interface must block. 
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public interface UserInteractionListener {
 	public boolean onUserConfirm(String header, String message, String question);

--- a/syncany-lib/src/main/java/org/syncany/plugins/local/LocalTransferManager.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/local/LocalTransferManager.java
@@ -55,15 +55,15 @@ import com.google.common.collect.Maps;
  * in special sub-folders:
  *
  * <ul>
- * <li>The <tt>databases</tt> folder keeps all the {@link DatabaseRemoteFile}s</li>
- * <li>The <tt>multichunks</tt> folder keeps the actual data within the {@link MultichunkRemoteFile}s</li>
+ * <li>The <code>databases</code> folder keeps all the {@link DatabaseRemoteFile}s</li>
+ * <li>The <code>multichunks</code> folder keeps the actual data within the {@link MultichunkRemoteFile}s</li>
  * </ul>
  *
  * <p>This plugin can be used for testing or to point to a repository
  * on a mounted remote device or network storage such as an NFS or a
  * Samba/NetBIOS share.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class LocalTransferManager extends AbstractTransferManager {
 	private static final Logger logger = Logger.getLogger(LocalTransferManager.class.getSimpleName());

--- a/syncany-lib/src/main/java/org/syncany/plugins/local/LocalTransferPlugin.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/local/LocalTransferPlugin.java
@@ -31,7 +31,7 @@ import org.syncany.plugins.transfer.TransferPlugin;
  * version of the plugin. It furthermore allows the instantiation
  * of a plugin-specific {@link org.syncany.plugins.local.LocalTransferSettings}.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class LocalTransferPlugin extends TransferPlugin {
 	public static final String ID = "local";

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/AbstractTransferManager.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/AbstractTransferManager.java
@@ -34,8 +34,8 @@ import org.syncany.util.StringUtil;
  * <p>This transfer manager is enhanced with the {@link TransactionAware}
  * and {@link Retriable} annotations, thereby making it reliable.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
+ * @author Christian Roth (christian.roth@port17.de)
  */
 @TransactionAware
 @Retriable(numberRetries = 3, sleepInterval = 3000)

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/Encrypted.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/Encrypted.java
@@ -26,7 +26,7 @@ import java.lang.annotation.Target;
  * Annotating a field with {@link org.syncany.plugins.transfer.Encrypted} implies that the field's value shell be stored
  * encrypted in the XML representation. Recommended when storing login credentials.
  *
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Christian Roth (christian.roth@port17.de)
  */
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/EncryptedTransferSettingsConverter.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/EncryptedTransferSettingsConverter.java
@@ -16,7 +16,7 @@ import com.google.common.collect.Lists;
  * annotation. Every marked field is encrypted with the user-specific
  * config key from {@link UserConfig}.
  * 
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Christian Roth (christian.roth@port17.de)
  */
 public class EncryptedTransferSettingsConverter implements Converter<String> {
 	private List<String> encryptedFields;

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/FileType.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/FileType.java
@@ -21,7 +21,7 @@ package org.syncany.plugins.transfer;
  * The file type is used to distinguish files from directories in the {@link Setup}
  * annotation, if a field represents a file/directory.
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public enum FileType {
 	NONE, FILE, FOLDER

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/NestedTransferPluginOption.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/NestedTransferPluginOption.java
@@ -28,7 +28,7 @@ import java.util.List;
  * <p>Nested plugin options are typically used to represent/use sub-plugins
  * within a certain plugin, e.g. to allow building a RAID0/1 plugin.
  *
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Christian Roth (christian.roth@port17.de)
  */
 public class NestedTransferPluginOption extends TransferPluginOption {
 	private final List<TransferPluginOption> options;

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/Setup.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/Setup.java
@@ -27,13 +27,13 @@ import java.lang.annotation.Target;
  * The {@link org.syncany.plugins.transfer.Setup} annotation alters the initialization process.
  *
  * @see org.syncany.plugins.transfer.TransferPluginOptions
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Christian Roth (christian.roth@port17.de)
  */
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Setup {
 	/**
-	 * A setting's position in the initialization process (lower comes first).<br/>
+	 * A setting's position in the initialization process (lower comes first).<br>
 	 * The order cannot be assured if two fields have the same order position.
 	 */
 	int order() default -1;

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/StorageException.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/StorageException.java
@@ -21,7 +21,7 @@ package org.syncany.plugins.transfer;
  * Exception thrown when any of the methods of the {@link TransferManager}
  * fail. Usually caused by broken sockets or a not available Internet connection.
  *  
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class StorageException extends Exception {
 	private static final long serialVersionUID = -311986990752074527L;

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/StorageTestResult.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/StorageTestResult.java
@@ -29,12 +29,12 @@ import org.simpleframework.xml.Element;
  *  <li>{@link TransferManager#testTargetExists()}: Tests whether the target exists.</li>
  *  <li>{@link TransferManager#testTargetCanWrite()}: Tests whether the target is writable.</li>
  *  <li>{@link TransferManager#testTargetCanCreate()}: Tests whether the target can be created if it does not 
- *      exist already. This is only called if <tt>testCreateTarget</tt> is set.</li>
+ *      exist already. This is only called if <code>testCreateTarget</code> is set.</li>
  *  <li>{@link TransferManager#testRepoFileExists()}: Tests whether the repo file exists.</li>
  * </ul>
  * 
  * @see TransferManager#test(boolean) 
- * @author Philipp Heckel <philipp.heckel@gmail.com>
+ * @author Philipp Heckel (philipp.heckel@gmail.com)
  */
 public class StorageTestResult {
 	@Element(name = "targetExists", required = true)

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/TransferManager.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/TransferManager.java
@@ -44,14 +44,14 @@ import org.syncany.plugins.transfer.files.SyncanyRemoteFile;
  * useful to place {@link MultichunkRemoteFile}s and {@link DatabaseRemoteFile}s
  * in a separate sub-folder on the remote storage.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public interface TransferManager {
 	/**
 	 * Establish a connection with the remote storage.
 	 *
 	 * <p>This method does not validate the correctness of the repository and
-	 * it does not create any folders. The former is done by {@link #test()}, the
+	 * it does not create any folders. The former is done by {@link #test(boolean)}, the
 	 * latter is done by {@link #init(boolean)}.
 	 *
 	 * @throws StorageException If the connection fails due to no Internet connection,
@@ -121,8 +121,8 @@ public interface TransferManager {
 	 *
 	 * <p> If the sourceFile does not exists, a {@link StorageMoveException} is thrown.
 	 *
-	 * @param source Existing remote file that is to be moved.
-	 * @param target Destination for the remote file.
+	 * @param sourceFile Existing remote file that is to be moved.
+	 * @param targetFile Destination for the remote file.
 	 * @throws StorageException If the connection fails due to no Internet connection,
 	 *         authentication errors, etc.
 	 */
@@ -146,7 +146,7 @@ public interface TransferManager {
 	 * Retrieves a list of all files in the remote repository, filtered by
 	 * the type of the desired file, i.e. by a sub-class of {@link RemoteFile}.
 	 *
-	 * @param remoteFileClass Filter class: <tt>RemoteFile</tt> or a sub-type thereof
+	 * @param remoteFileClass Filter class: <code>RemoteFile</code> or a sub-type thereof
 	 * @return Returns a list of remote files. In the map, the key is the file name,
 	 *         the value the entire {@link RemoteFile} object.
 	 * @throws StorageException If the connection fails due to no Internet connection,
@@ -166,26 +166,26 @@ public interface TransferManager {
 	 *  <li>{@link #testTargetExists()}: Tests whether the target exists.</li>
 	 *  <li>{@link #testTargetCanWrite()}: Tests whether the target is writable.</li>
 	 *  <li>{@link #testTargetCanCreate()}: Tests whether the target can be created if it does not
-	 *      exist already. This is only called if <tt>testCreateTarget</tt> is set.</li>
+	 *      exist already. This is only called if <code>testCreateTarget</code> is set.</li>
 	 *  <li>{@link #testRepoFileExists()}: Tests whether the repo file exists.</li>
 	 * </ul>
 	 *
 	 * @return Returns the result of testing the repository.
-	 * @param testCreateTarget If <tt>true</tt>, the test will test if the target can be created in case
-	 *        it does not exist. If <tt>false</tt>, this test will be skipped.
+	 * @param testCreateTarget If <code>true</code>, the test will test if the target can be created in case
+	 *        it does not exist. If <code>false</code>, this test will be skipped.
 	 * @see StorageTestResult
 	 */
 	public StorageTestResult test(boolean testCreateTarget);
 
 	/**
 	 * Tests whether the target path/folder <b>exists</b>. This might be done by listing the parent path/folder
-	 * or by retrieving metadata about the target. The method returns <tt>true</tt> if the target exists,
-	 * <tt>false</tt> otherwise.
+	 * or by retrieving metadata about the target. The method returns <code>true</code> if the target exists,
+	 * <code>false</code> otherwise.
 	 *
 	 * <p>This method is called by the {@link #test(boolean)} method (only during repository initialization
 	 * or initial connection).
 	 *
-	 * @return Returns <tt>true</tt> if the target exists, <tt>false</tt> otherwise
+	 * @return Returns <code>true</code> if the target exists, <code>false</code> otherwise
 	 * @throws StorageException If the test cannot be performed, e.g. due to a connection failure
 	 */
 	public boolean testTargetExists() throws StorageException;
@@ -193,13 +193,13 @@ public interface TransferManager {
 	/**
 	 * Tests whether the target path/folder is <b>writable</b> by the application. This method may either
 	 * check the write permissions of the target or actually write a test file to check write access. If the
-	 * target does not exist, <tt>false</tt> is returned. If the target exists and is writable, <tt>true</tt>
+	 * target does not exist, <code>false</code> is returned. If the target exists and is writable, <code>true</code>
 	 * is returned.
 	 *
 	 * <p>This method is called by the {@link #test(boolean)} method (only during repository initialization
 	 * or initial connection).
 	 *
-	 * @return Returns <tt>true</tt> if the target can be written to, <tt>false</tt> otherwise
+	 * @return Returns <code>true</code> if the target can be written to, <code>false</code> otherwise
 	 * @throws StorageException If the test cannot be performed, e.g. due to a connection failure
 	 */
 	public boolean testTargetCanWrite() throws StorageException;
@@ -209,25 +209,25 @@ public interface TransferManager {
 	 * may either check the permissions of the parent path/folder or actually create and delete the target to
 	 * determine create permissions.
 	 *
-	 * <p>If the target already exists, the method returns <tt>true</tt>. If it does not, but it can be created
-	 * (according to tests of this method), it also returns <tt>true</tt>. In all other cases, <tt>false</tt> is returned.
+	 * <p>If the target already exists, the method returns <code>true</code>. If it does not, but it can be created
+	 * (according to tests of this method), it also returns <code>true</code>. In all other cases, <code>false</code> is returned.
 	 *
-	 * <p>This method is called by the {@link #test(boolean)} method, <b>but only if</b> the <tt>testCreateTarget</tt> flag
-	 * is set to <tt>true</tt>!
+	 * <p>This method is called by the {@link #test(boolean)} method, <b>but only if</b> the <code>testCreateTarget</code> flag
+	 * is set to <code>true</code>!
 	 *
-	 * @return Returns <tt>true</tt> if the target can be created or already exists, <tt>false</tt> otherwise
+	 * @return Returns <code>true</code> if the target can be created or already exists, <code>false</code> otherwise
 	 * @throws StorageException If the test cannot be performed, e.g. due to a connection failure
 	 */
 	public boolean testTargetCanCreate() throws StorageException;
 
 	/**
-	 * Tests whether the <b>repository file exists</b> (see {@link SyncanyRemoteFile}). This method is called by the {@link #test()} method
+	 * Tests whether the <b>repository file exists</b> (see {@link SyncanyRemoteFile}). This method is called by the {@link #test(boolean)} method
 	 * (only during repository initialization (or initial connection).
 	 *
 	 * <p>This method is called by the {@link #test(boolean)} method (only during repository initialization
 	 * or initial connection).
 	 *
-	 * @return Returns <tt>true</tt> if the repository is valid, <tt>false</tt> otherwise
+	 * @return Returns <code>true</code> if the repository is valid, <code>false</code> otherwise
 	 * @throws StorageException If the test cannot be performed, e.g. due to a connection failure
 	 */
 	public boolean testRepoFileExists() throws StorageException;

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/TransferManagerFactory.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/TransferManagerFactory.java
@@ -58,8 +58,8 @@ import com.google.common.collect.Sets;
  * @see Feature
  * @see FeatureTransferManager
  * @see TransferManager
- * @author Christian Roth <christian.roth@port17.de>
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Christian Roth (christian.roth@port17.de)
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class TransferManagerFactory {
 	private static final Logger logger = Logger.getLogger(TransferManagerFactory.class.getSimpleName());

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/TransferPlugin.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/TransferPlugin.java
@@ -29,7 +29,7 @@ import org.syncany.util.ReflectionUtil;
  * The transfer plugin is a special plugin responsible for transferring files
  * to the remote storage. Implementations must provide implementations for
  * {@link TransferPlugin} (this class), {@link TransferSettings} (connection
- * details) and {@link TransferManager} (transfer methods).<br/><br/>
+ * details) and {@link TransferManager} (transfer methods).<br><br>
  *
  * <p>Plugins have to follow a naming convention:
  * <ul>
@@ -39,13 +39,13 @@ import org.syncany.util.ReflectionUtil;
  *      subsequent character.</li>
  * </ul>
  *
- * <p>Example:</b> 
+ * <p>Example:</p>
  * A plugin is called DummyPlugin, hence <i>org.syncany.plugins.dummy_plugin.DummyPluginTransferPlugin</i> is the
  * plugin's {@link TransferPlugin} class and <i>org.syncany.plugins.dummy_plugin.DummyPluginTransferSettings</i> is the
  * corresponding {@link TransferSettings} implementation.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
+ * @author Christian Roth (christian.roth@port17.de)
  */
 public abstract class TransferPlugin extends Plugin {
 	public TransferPlugin(String pluginId) {
@@ -57,7 +57,7 @@ public abstract class TransferPlugin extends Plugin {
 	 *
 	 * @return Empty plugin-specific {@link org.syncany.plugins.transfer.TransferSettings} instance.
 	 * @throws StorageException Thrown if no {@link org.syncany.plugins.transfer.TransferSettings} are attached to a
-	 *         plugin using {@link org.syncany.plugins.transfer.PluginSettings}
+	 *         plugin
 	 */
 	@SuppressWarnings("unchecked")
 	public final <T extends TransferSettings> T createEmptySettings() throws StorageException {
@@ -86,7 +86,7 @@ public abstract class TransferPlugin extends Plugin {
 	 * @param config A valid {@link org.syncany.config.Config} instance.
 	 * @return A initialized, plugin-specific {@link org.syncany.plugins.transfer.TransferManager} instance.
 	 * @throws StorageException Thrown if no (valid) {@link org.syncany.plugins.transfer.TransferManager} are attached to
-	*  a plugin using {@link org.syncany.plugins.transfer.PluginManager}
+	*  a plugin
 	 */
 	@SuppressWarnings("unchecked")
 	public final <T extends TransferManager> T createTransferManager(TransferSettings transferSettings, Config config) throws StorageException {

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/TransferPluginOption.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/TransferPluginOption.java
@@ -29,7 +29,7 @@ import org.syncany.util.ReflectionUtil;
  * is created during the initialization from the {@link Setup} annotation
  * to aid the guided repository setup (init and connect).
  *
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Christian Roth (christian.roth@port17.de)
  */
 public class TransferPluginOption {
 	public enum ValidationResult {

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/TransferPluginOptionCallback.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/TransferPluginOptionCallback.java
@@ -22,7 +22,7 @@ package org.syncany.plugins.transfer;
  * corresponding setting is queried.
  *
  * @see org.syncany.plugins.transfer.TransferPluginOptions
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Christian Roth (christian.roth@port17.de)
  */
 public interface TransferPluginOptionCallback {
 	/**

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/TransferPluginOptionConverter.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/TransferPluginOptionConverter.java
@@ -22,7 +22,7 @@ package org.syncany.plugins.transfer;
  * convert a user input before setting it.
  *
  * @see org.syncany.plugins.transfer.TransferPluginOptions
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Christian Roth (christian.roth@port17.de)
  */
 public interface TransferPluginOptionConverter {
 	/**

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/TransferPluginOptions.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/TransferPluginOptions.java
@@ -32,7 +32,7 @@ import com.google.common.primitives.Ints;
  * Helper class to read the options of a {@link TransferSettings} using the
  * {@link Setup} and {@link Element} annotations.
  *
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Christian Roth (christian.roth@port17.de)
  */
 public class TransferPluginOptions {
 	private static final int MAX_NESTED_LEVELS = 3;

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/TransferPluginUtil.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/TransferPluginUtil.java
@@ -29,7 +29,7 @@ import com.google.common.base.CaseFormat;
  * the required transfer plugin classes -- namely {@link TransferSettings},
  * {@link TransferManager} and {@link TransferPlugin}.
  *
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Christian Roth (christian.roth@port17.de)
  */
 public abstract class TransferPluginUtil {
 	private static final String PLUGIN_PACKAGE_NAME_REGEX = "^" + Plugin.class.getPackage().getName().replace(".", "\\.") + "\\.([a-z0-9_]+)$";

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/TransferSettings.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/TransferSettings.java
@@ -49,8 +49,8 @@ import com.google.common.base.Objects;
  * <p>Options for a plugin specific {@link TransferSettings} can be defined using the
  * {@link Element} annotation. Furthermore some Syncany-specific annotations are available.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
+ * @author Christian Roth (christian.roth@port17.de)
  */
 public abstract class TransferSettings {
 	private static final Logger logger = Logger.getLogger(TransferSettings.class.getName());

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/features/Feature.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/features/Feature.java
@@ -39,7 +39,7 @@ import org.syncany.plugins.transfer.TransferManagerFactory;
  * @see TransferManager
  * @see TransferManagerFactory
  * @see FeatureTransferManager
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/features/FeatureExtension.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/features/FeatureExtension.java
@@ -25,7 +25,7 @@ package org.syncany.plugins.transfer.features;
  * 
  * @see Feature
  * @see FeatureTransferManager
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Christian Roth (christian.roth@port17.de)
  */
 public interface FeatureExtension {
 	// Marker interface

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/features/FeatureTransferManager.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/features/FeatureTransferManager.java
@@ -38,7 +38,7 @@ import org.syncany.plugins.transfer.TransferManagerFactory;
  * 
  * @see Feature
  * @see FeatureExtension
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public interface FeatureTransferManager extends TransferManager {
 	// Marker interface

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/features/PathAware.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/features/PathAware.java
@@ -26,6 +26,7 @@ import org.syncany.plugins.transfer.features.PathAwareFeatureTransferManager.Pat
 import org.syncany.plugins.transfer.files.MultichunkRemoteFile;
 import org.syncany.plugins.transfer.files.RemoteFile;
 import org.syncany.plugins.transfer.files.TempRemoteFile;
+import org.syncany.plugins.transfer.TransferManager;
 
 /**
  * Feature annotation to mark a transfer manager of transfer plugins
@@ -37,7 +38,7 @@ import org.syncany.plugins.transfer.files.TempRemoteFile;
  * on how many files can be stored in a single folder, e.g. the Dropbox plugin can only
  * store 25,000 files in one folder.  
  * 
- * <p>This annotation is only recognized if used on a {@link TransferManager}. If 
+ * <p>This annotation is only recognized if used on a {@link TransferManager}. If
  * applied, it wraps the original transfer manager in a {@link PathAwareFeatureTransferManager},
  * which defines details for the subfoldering, such as the depths of the subfolders, the path
  * separator or other relevant settings. 
@@ -54,7 +55,7 @@ import org.syncany.plugins.transfer.files.TempRemoteFile;
  * @see PathAwareFeatureTransferManager
  * @see PathAwareFeatureExtension
  * @see PathAwareRemoteFileAttributes 
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Christian Roth (christian.roth@port17.de)
  */
 @Feature(required = false)
 @Target(ElementType.TYPE)

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/features/PathAwareFeatureExtension.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/features/PathAwareFeatureExtension.java
@@ -32,7 +32,7 @@ import org.syncany.plugins.transfer.TransferManager;
  * 
  * @see PathAware
  * @see PathAwareFeatureTransferManager
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Christian Roth (christian.roth@port17.de)
  */
 public interface PathAwareFeatureExtension extends FeatureExtension {
 	/**

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/features/PathAwareFeatureTransferManager.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/features/PathAwareFeatureTransferManager.java
@@ -60,7 +60,7 @@ import com.google.common.hash.Hashing;
  * @see PathAware
  * @see PathAwareFeatureExtension
  * @see PathAwareRemoteFileAttributes
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Christian Roth (christian.roth@port17.de)
  */
 public class PathAwareFeatureTransferManager implements FeatureTransferManager {
 	private static final Logger logger = Logger.getLogger(PathAwareFeatureTransferManager.class.getSimpleName());

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/features/ReadAfterWriteConsistent.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/features/ReadAfterWriteConsistent.java
@@ -24,16 +24,16 @@ import java.lang.annotation.Target;
 
 /**
  * <p>Some storage backends do not guarantee that a file immediately exists on the
- * remote side after it is uploaded or moved.<br/>
+ * remote side after it is uploaded or moved.<br>
  * This feature handles such cases by relaxing the strong assumption that a file
  * is immediately available after creation due to upload or move operations.
  *
  * <p>The {@link ReadAfterWriteConsistentFeatureTransferManager} throttles existence check
- * using a simple exponential method:<br/>
+ * using a simple exponential method:<br>
  *
- * <code>throttle(n) = 3 ^ n * 100 ms, with n being the current iteration
+ * <code>throttle(n) = 3 ^ n * 100 ms</code>, with n being the current iteration
  *
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Christian Roth (christian.roth@port17.de)
  */
 @Feature(required = false)
 @Target(ElementType.TYPE)

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/features/ReadAfterWriteConsistentFeatureExtension.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/features/ReadAfterWriteConsistentFeatureExtension.java
@@ -26,7 +26,7 @@ import org.syncany.plugins.transfer.files.RemoteFile;
  * feature in order to extend a {@link TransferManager} that was marked as 'read write consistent'
  * with the required methods to verify if a file exists on the remote side.
  *
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Christian Roth (christian.roth@port17.de)
  */
 public interface ReadAfterWriteConsistentFeatureExtension extends FeatureExtension {
 	/**

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/features/ReadAfterWriteConsistentFeatureTransferManager.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/features/ReadAfterWriteConsistentFeatureTransferManager.java
@@ -37,11 +37,11 @@ import org.syncany.util.ReflectionUtil;
  * because some storage backends do no guarantee that a file immediately exists after
  * creation.
  *
- * <p>It throttles existence check using a simple exponential method:<br/>
+ * <p>It throttles existence check using a simple exponential method:<br>
  *
- * <code>throttle(n) = 3 ^ n * 100 ms, with n being the current iteration
+ * <code>throttle(n) = 3 ^ n * 100 ms</code>, with n being the current iteration
  *
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Christian Roth (christian.roth@port17.de)
  */
 public class ReadAfterWriteConsistentFeatureTransferManager implements FeatureTransferManager {
 	private static final Logger logger = Logger.getLogger(ReadAfterWriteConsistentFeatureTransferManager.class.getSimpleName());

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/features/Retriable.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/features/Retriable.java
@@ -17,6 +17,8 @@
  */
 package org.syncany.plugins.transfer.features;
 
+import org.syncany.plugins.transfer.TransferManager;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -26,13 +28,13 @@ import java.lang.annotation.Target;
  * Feature annotation to make a transfer manager more reliable by making 
  * its core methods retriable. 
  * 
- * <p>This annotation is only recognized if used on a {@link FTransferManager}. If 
+ * <p>This annotation is only recognized if used on a {@link TransferManager}. If
  * applied, it wraps the original transfer manager in a {@link RetriableFeatureTransferManager}.
  * 
  * <p>The options that can be defined in this feature annotation are how often a method
  * will be retried, and how long the sleep interval between these retries is.
  * 
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Christian Roth (christian.roth@port17.de)
  */
 @Feature(required = true)
 @Target(ElementType.TYPE)

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/features/RetriableFeatureTransferManager.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/features/RetriableFeatureTransferManager.java
@@ -38,7 +38,7 @@ import org.syncany.plugins.transfer.files.RemoteFile;
  * method is retried N times before the exception is actually thrown to the caller.
  * Between retries, the method waits M seconds.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class RetriableFeatureTransferManager implements FeatureTransferManager {
 	private static final Logger logger = Logger.getLogger(RetriableFeatureTransferManager.class.getSimpleName());

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/features/TransactionAware.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/features/TransactionAware.java
@@ -23,7 +23,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Christian Roth (christian.roth@port17.de)
  */
 @Feature(required = true)
 @Target(ElementType.TYPE)

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/files/ActionRemoteFile.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/files/ActionRemoteFile.java
@@ -32,7 +32,7 @@ import org.syncany.plugins.transfer.StorageException;
  * <b>action-&lt;operationname&gt;-&lt;machinename&gt;-&lt;timestamp&gt;</b>. Initializing an 
  * instance with a non-matching name will throw an exception.
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class ActionRemoteFile extends RemoteFile {
 	private static final Pattern NAME_PATTERN = Pattern.compile("action-(up|down|cleanup|restore)-([^-]+)-(\\d+)");

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/files/CleanupRemoteFile.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/files/CleanupRemoteFile.java
@@ -49,7 +49,6 @@ public class CleanupRemoteFile extends RemoteFile {
 	/**
 	 * Initializes a new transaction file, given which cleanup has occurred 
 	 * 
-	 * @param remoteTransaction the remoteTransaction for which a file is needed
 	 * @throws StorageException If the name is not match the name pattern
 	 */
 	public CleanupRemoteFile(long cleanupNumber) throws StorageException {

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/files/DatabaseRemoteFile.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/files/DatabaseRemoteFile.java
@@ -32,7 +32,7 @@ import org.syncany.plugins.transfer.StorageException;
  * <p><b>Note:</b> The class implements a {@link Comparable} interface and
  * can be sorted by name and client version.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class DatabaseRemoteFile extends RemoteFile implements Comparable<DatabaseRemoteFile> {
 	private static final Pattern NAME_PATTERN = Pattern.compile("database-([^-]+)-(\\d+)");
@@ -43,8 +43,8 @@ public class DatabaseRemoteFile extends RemoteFile implements Comparable<Databas
 
 	/**
 	 * Initializes a new database file, given a name. This constructor might
-	 * be called by the {@link RemoteFileFactory#createRemoteFile(String, Class) createRemoteFile()}
-	 * method of the {@link RemoteFileFactory}.
+	 * be called by the {@link RemoteFile#createRemoteFile(String, Class) createRemoteFile()}
+	 * method of the {@link RemoteFile}.
 	 *
 	 * <p>If the pattern matches, the client name and the client version are set, and can be
 	 * queried by {@link #getClientName()} and {@link #getClientVersion()}.

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/files/MasterRemoteFile.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/files/MasterRemoteFile.java
@@ -27,7 +27,7 @@ import org.syncany.plugins.transfer.StorageException;
  * Initializing an instance with a different name will throw an
  * exception.
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class MasterRemoteFile extends RemoteFile {
 	private static final String NAME_FORMAT = "master";
@@ -42,8 +42,8 @@ public class MasterRemoteFile extends RemoteFile {
 	
 	/**
 	 * Initializes a new master file, given a name. This constructor might 
-	 * be called by the {@link RemoteFileFactory#createRemoteFile(String, Class) createRemoteFile()}
-	 * method of the {@link RemoteFileFactory}. 
+	 * be called by the {@link RemoteFile#createRemoteFile(String, Class) createRemoteFile()}
+	 * method of the {@link RemoteFile}.
 	 *  
 	 * @param name Master file name; <b>must</b> always be <b>master</b> 
 	 * @throws StorageException If the name is not <b>master</b>

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/files/MultichunkRemoteFile.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/files/MultichunkRemoteFile.java
@@ -31,7 +31,7 @@ import org.syncany.util.StringUtil;
  * <b>multichunk-&lt;multichunkid&gt;</b>. Initializing an 
  * instance with a non-matching name will throw an exception.
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class MultichunkRemoteFile extends RemoteFile {
 	private static final Pattern NAME_PATTERN = Pattern.compile("multichunk-([a-f0-9]+)");
@@ -41,8 +41,8 @@ public class MultichunkRemoteFile extends RemoteFile {
 
 	/**
 	 * Initializes a new multichunk file, given a name. This constructor might 
-	 * be called by the {@link RemoteFileFactory#createRemoteFile(String, Class) createRemoteFile()}
-	 * method of the {@link RemoteFileFactory}. 
+	 * be called by the {@link RemoteFile#createRemoteFile(String, Class) createRemoteFile()}
+	 * method of the {@link RemoteFile}.
 	 * 
 	 * <p>If the pattern matches, the multichunk identifier is set and can be  
 	 * queried by {@link #getMultiChunkId()}.

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/files/RemoteFile.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/files/RemoteFile.java
@@ -31,7 +31,7 @@ import com.google.common.collect.Maps;
  * A remote file represents a file object on a remote storage. Its purpose is to
  * identify a file and allow {@link TransferManager}s to upload/download local files.
  *
- * <p>Transfer manager operations take either <tt>RemoteFile</tt> instances, or classes
+ * <p>Transfer manager operations take either <code>RemoteFile</code> instances, or classes
  * that extend this class. Depending on the type of the sub-class, they might store the
  * files at a different location or in a different format to optimize performance.
  * 
@@ -41,9 +41,9 @@ import com.google.common.collect.Maps;
  *
  * <p><b>Important:</b> Sub-classes must offer a
  * {@link RemoteFile#RemoteFile(String) one-parameter constructor} that takes a
- * <tt>String</tt> argument. This constructor is required by the {@link RemoteFileFactory}.
+ * <code>String</code> argument. This constructor is required by the {@link RemoteFile}.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public abstract class RemoteFile {
 	private static final Logger logger = Logger.getLogger(RemoteFile.class.getSimpleName());
@@ -59,15 +59,15 @@ public abstract class RemoteFile {
 	 * to identify a file on the remote storage.
 	 *
 	 * <p>The constructor parses and validates the given name using the
-	 * {@link #validateName(String) validateName()} method. While <tt>RemoteFile</tt> has no name
+	 * {@link #validateName(String) validateName()} method. While <code>RemoteFile</code> has no name
 	 * pattern (and never throws an exception), sub-classes might.
 	 *
 	 * <p><b>Important:</b> Sub-classes must also implement a one-parameter constructor that takes a
-	 * <tt>String</tt> argument. This constructor is required by the {@link RemoteFileFactory}.
+	 * <code>String</code> argument. This constructor is required by the {@link RemoteFile}.
 	 *
 	 * @param name The name of the file (as it is identified by Syncany)
-	 * @throws StorageException If the name does not match the name pattern defined by the class.<br />
-	 *         <b>Note:</b> <tt>RemoteFile</tt> does never throw this exceptions, however, subclasses might.
+	 * @throws StorageException If the name does not match the name pattern defined by the class.<br>
+	 *         <b>Note:</b> <code>RemoteFile</code> does never throw this exceptions, however, subclasses might.
 	 */
 	public RemoteFile(String name) throws StorageException {
 		this.name = validateName(name);
@@ -100,13 +100,13 @@ public abstract class RemoteFile {
 
 	/**
 	 * Parses the name of the file and validates it against the classes name pattern. While
-	 * <tt>RemoteFile</tt> has no name pattern (and never throws an exception), sub-classes might by
+	 * <code>RemoteFile</code> has no name pattern (and never throws an exception), sub-classes might by
 	 * overriding this method.
 	 *
 	 * @param name The name of the file (as it is identified by Syncany)
 	 * @return Returns a (potentially changed) name, after validating the name
-	 * @throws StorageException If the name does not match the name pattern defined by the class.<br />
-	 *         <b>Note:</b> <tt>RemoteFile</tt> does never throw this exceptions, however, subclasses might.
+	 * @throws StorageException If the name does not match the name pattern defined by the class.<br>
+	 *         <b>Note:</b> <code>RemoteFile</code> does never throw this exceptions, however, subclasses might.
 	 */
 	protected String validateName(String name) throws StorageException {
 		return name;
@@ -116,10 +116,10 @@ public abstract class RemoteFile {
 	 * Creates a remote file based on a name and a class name.
 	 *
 	 * <p>The name must match the corresponding name pattern, and the class name
-	 * can either be <tt>RemoteFile</tt>, or a sub-class thereof.
+	 * can either be <code>RemoteFile</code>, or a sub-class thereof.
 	 *
 	 * @param name The name of the remote file
-	 * @param remoteFileClass Class name of the object to instantiate, <tt>RemoteFile</tt> or a sub-class thereof
+	 * @param remoteFileClass Class name of the object to instantiate, <code>RemoteFile</code> or a sub-class thereof
 	 * @return Returns a new object of the given class
 	 */
 	public static <T extends RemoteFile> T createRemoteFile(String name, Class<T> remoteFileClass) throws StorageException {
@@ -136,7 +136,7 @@ public abstract class RemoteFile {
 	 * file name.
 	 *
 	 * <p>The name must match the corresponding name pattern (nameprefix-...), and
-	 * the derived class can either be <tt>RemoteFile</tt>, or a sub-class thereof.
+	 * the derived class can either be <code>RemoteFile</code>, or a sub-class thereof.
 	 *
 	 * @param name The name of the remote file
 	 * @return Returns a new object of the given class

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/files/RemoteFileAttributes.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/files/RemoteFileAttributes.java
@@ -18,7 +18,7 @@
 package org.syncany.plugins.transfer.files;
 
 /**
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Christian Roth (christian.roth@port17.de)
  */
 
 public abstract class RemoteFileAttributes {

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/files/SyncanyRemoteFile.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/files/SyncanyRemoteFile.java
@@ -28,7 +28,7 @@ import org.syncany.plugins.transfer.StorageException;
  * Initializing an instance with a different name will throw an
  * exception.
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class SyncanyRemoteFile extends RemoteFile {
 	private static final String NAME_FORMAT = "syncany";
@@ -43,8 +43,8 @@ public class SyncanyRemoteFile extends RemoteFile {
 
 	/**
 	 * Initializes a new repo file, given a name. This constructor might 
-	 * be called by the {@link RemoteFileFactory#createRemoteFile(String, Class) createRemoteFile()}
-	 * method of the {@link RemoteFileFactory}. 
+	 * be called by the {@link RemoteFile#createRemoteFile(String, Class) createRemoteFile()}
+	 * method of the {@link RemoteFile}.
 	 *  
 	 * @param name Repo file name; <b>must</b> always be <b>syncany</b> 
 	 * @throws StorageException If the name is not <b>syncany</b>

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/oauth/OAuth.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/oauth/OAuth.java
@@ -30,8 +30,8 @@ import org.syncany.plugins.transfer.TransferSettings;
  * during the initialization process and the {@link OAuthGenerator} (provided via the
  * help of the {@link #value()} field) will be able to check that token.
  *
- * @author Philipp Heckel <philipp.heckel@gmail.com>
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Philipp Heckel (philipp.heckel@gmail.com)
+ * @author Christian Roth (christian.roth@port17.de)
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
@@ -54,14 +54,14 @@ public @interface OAuth {
 	/**
 	 * If no specific port is provided (or {@value #RANDOM_PORT} is used), the {@link OAuthTokenWebListener} will choose a
 	 * random port from the range of {@value OAuthTokenWebListener#PORT_LOWER} and
-	 * {@value OAuthTokenWebListener#PORT_UPPER}.<br/>
+	 * {@value OAuthTokenWebListener#PORT_UPPER}.<br>
 	 * Needed if an OAuth provider uses preset and strict redirect URLs.
 	 */
 	int callbackPort() default RANDOM_PORT; // -1 is random
 
 	/**
 	 * If no specific name is provided (or {@value #PLUGIN_ID} is used), the {@link OAuthTokenWebListener} will choose a
-	 * random identifier for the OAuth process.<br/>
+	 * random identifier for the OAuth process.<br>
 	 * Needed if an OAuth provider uses preset and strict redirect URLs.
 	 */
 	String callbackId() default PLUGIN_ID; // equals plugin id

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/oauth/OAuthGenerator.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/oauth/OAuthGenerator.java
@@ -28,13 +28,13 @@ import org.syncany.plugins.transfer.TransferSettings;
  * a generator class can be used to create the authentication URL and
  * check the user-provided token. The concrete implementation of this
  * interface should be provided to the {@link TransferSettings} class
- * via the {@link OAuth} annotation.<br/>
+ * via the {@link OAuth} annotation.<br>
  * A generator can be extended with {@link OAuthGenerator.WithInterceptor},
  * {@link OAuthGenerator.WithExtractor} and
  * {@link OAuthGenerator.WithNoRedirectMode}.
  *
- * @author Philipp Heckel <philipp.heckel@gmail.com>
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Philipp Heckel (philipp.heckel@gmail.com)
+ * @author Christian Roth (christian.roth@port17.de)
  */
 public interface OAuthGenerator {
 	/**
@@ -61,7 +61,7 @@ public interface OAuthGenerator {
 	/**
 	 * Use a custom {@link OAuthTokenInterceptor} instead of the default one which depends on the {@link OAuthMode} in use.
 	 *
-	 * @see {@link OAuthTokenInterceptor}
+	 * See: {@link OAuthTokenInterceptor}
 	 */
 	interface WithInterceptor {
 		OAuthTokenInterceptor getInterceptor();
@@ -70,18 +70,18 @@ public interface OAuthGenerator {
 	/**
 	 * Use a custom {@link OAuthTokenExtractor} instead of the default one which depends on the {@link OAuthMode} in use.
 	 *
-	 * @see {@link OAuthTokenExtractor}
+	 * See: {@link OAuthTokenExtractor}
 	 */
 	interface WithExtractor {
 		OAuthTokenExtractor getExtractor();
 	}
 
 	/**
-	 * If an OAuth based plugin also supports copy&pasting a token from a website it should extend this interface.
+	 * If an OAuth based plugin also supports copy&amp;pasting a token from a website it should extend this interface.
 	 */
 	interface WithNoRedirectMode {
 		/**
-		 * Called if Syncany is started in headless mode which does not support redirect_to URLs.<br/>
+		 * Called if Syncany is started in headless mode which does not support redirect_to URLs.<br>
 		 * The website should output a token which can be copied over to Syncany's repo wizard.
 		 *
 		 * @return A URL with no redirect URL

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/oauth/OAuthMode.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/oauth/OAuthMode.java
@@ -5,7 +5,7 @@ package org.syncany.plugins.transfer.oauth;
  * a very short lifetime) to perform different API actions. The second mode is used by server and requires a separate step to transform an
  * Authorization token into an actual Access token. Syncany supports both modes out of the box.
  *
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Christian Roth (christian.roth@port17.de)
  */
 
 public enum OAuthMode {

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/oauth/OAuthTokenExtractor.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/oauth/OAuthTokenExtractor.java
@@ -5,9 +5,9 @@ package org.syncany.plugins.transfer.oauth;
  * Such URLs a are typically callback URLs called by an oauth provider who adds token and status fields to such an URL.
  * {@link OAuthTokenExtractors} provides some predefined OAuthTokenExtractors.
  *
- * @see {@link OAuthTokenExtractors}
+ * <p>See: {@link OAuthTokenExtractors}</p>
  *
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Christian Roth (christian.roth@port17.de)
  */
 
 public interface OAuthTokenExtractor {

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/oauth/OAuthTokenExtractors.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/oauth/OAuthTokenExtractors.java
@@ -12,7 +12,7 @@ import com.google.common.base.Charsets;
 /**
  * Factory class to generate some common {@link OAuthTokenExtractor}s.
  *
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Christian Roth (christian.roth@port17.de)
  */
 public abstract class OAuthTokenExtractors {
 	private static final Logger logger = Logger.getLogger(OAuthTokenExtractors.class.getName());

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/oauth/OAuthTokenFinish.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/oauth/OAuthTokenFinish.java
@@ -3,7 +3,7 @@ package org.syncany.plugins.transfer.oauth;
 /**
  * A {@link OAuthTokenFinish} is a container to hold a pair of a token and a CSRF field.
  *
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Christian Roth (christian.roth@port17.de)
  */
 
 public class OAuthTokenFinish {

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/oauth/OAuthTokenInterceptor.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/oauth/OAuthTokenInterceptor.java
@@ -6,9 +6,9 @@ import io.undertow.server.HttpHandler;
  * A OAuthTokenInterceptor is an extension of an {@link HttpHandler} which intercepts calls to a callback URL depending
  * on the queried path.
  *
- * @see {@link OAuthTokenInterceptors}
+ * <p>See: {@link OAuthTokenInterceptors}</p>
  *
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Christian Roth (christian.roth@port17.de)
  */
 
 public interface OAuthTokenInterceptor extends HttpHandler {

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/oauth/OAuthTokenInterceptors.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/oauth/OAuthTokenInterceptors.java
@@ -14,7 +14,7 @@ import io.undertow.util.StatusCodes;
 /**
  * Factory class to generate some common {@link OAuthTokenInterceptor}s.
  *
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Christian Roth (christian.roth@port17.de)
  */
 public abstract class OAuthTokenInterceptors {
 

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/oauth/OAuthTokenWebListener.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/oauth/OAuthTokenWebListener.java
@@ -32,7 +32,7 @@ import io.undertow.util.Headers;
  * {@link OAuthTokenInterceptor} depending on a path defined by the interceptor itself. Furthermore it does the token
  * parsing in the URL using a {@link OAuthTokenExtractor}.
  *
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Christian Roth (christian.roth@port17.de)
  */
 
 public class OAuthTokenWebListener implements Callable<OAuthTokenFinish> {

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/oauth/OAuthWebResponse.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/oauth/OAuthWebResponse.java
@@ -3,7 +3,7 @@ package org.syncany.plugins.transfer.oauth;
 /**
  * A website which is shown to a user during the oauth process.
  *
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Christian Roth (christian.roth@port17.de)
  */
 
 class OAuthWebResponse {

--- a/syncany-lib/src/main/java/org/syncany/plugins/transfer/oauth/OAuthWebResponses.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/transfer/oauth/OAuthWebResponses.java
@@ -9,7 +9,7 @@ import io.undertow.util.StatusCodes;
  * Factory class to generate some common {@link OAuthWebResponse}s. It uses html sites residing in the ressource folder,
  * but provides plain text fallbacks if a specific site cannot be read.
  *
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Christian Roth (christian.roth@port17.de)
  */
 
 public abstract class OAuthWebResponses {
@@ -17,7 +17,7 @@ public abstract class OAuthWebResponses {
 	public static final String RESOURCE_DIR = "/org/syncany/plugins/oauth/";
 
 	/**
-	 * This {@link OAuthWebResponse} is used when a token was succesfully extracted. It uses <tt>ValidWebResponse.html</tt> which should be placed in
+	 * This {@link OAuthWebResponse} is used when a token was succesfully extracted. It uses <code>ValidWebResponse.html</code> which should be placed in
 	 * {@value #RESOURCE_DIR}.
 	 *
 	 * @return Either the parsed html file or a fallback string.
@@ -27,7 +27,7 @@ public abstract class OAuthWebResponses {
 	}
 
 	/**
-	 * This {@link OAuthWebResponse} is used when there was an error during the OAuth process. It uses <tt>BadRequestWebResponse.html</tt> which
+	 * This {@link OAuthWebResponse} is used when there was an error during the OAuth process. It uses <code>BadRequestWebResponse.html</code> which
 	 * should be placed in {@value #RESOURCE_DIR}.
 	 *
 	 * @return Either the parsed html file or a fallback string.

--- a/syncany-lib/src/main/java/org/syncany/plugins/web/WebInterfacePlugin.java
+++ b/syncany-lib/src/main/java/org/syncany/plugins/web/WebInterfacePlugin.java
@@ -25,7 +25,7 @@ import org.syncany.plugins.Plugin;
  * Web interface plugins implement a web frontend by implementing this
  * class. 
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public abstract class WebInterfacePlugin extends Plugin {
 	public WebInterfacePlugin(String pluginId) {

--- a/syncany-lib/src/main/java/org/syncany/util/SqlRunner.java
+++ b/syncany-lib/src/main/java/org/syncany/util/SqlRunner.java
@@ -33,7 +33,7 @@ import java.util.regex.Pattern;
  * Helper class to execute SQL scripts on a given connection. The script honors SQL comments and
  * separately executes commands one after another.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class SqlRunner {
 	private static final Logger logger = Logger.getLogger(SqlRunner.class.getSimpleName());

--- a/syncany-lib/src/main/resources/org/syncany/plugins/oauth/BadRequestWebResponse.html
+++ b/syncany-lib/src/main/resources/org/syncany/plugins/oauth/BadRequestWebResponse.html
@@ -27,7 +27,7 @@
         <h2>Syncany</h2>
 
         <p class="tagline">
-            There was an error while requesting the OAuth token.<br />
+            There was an error while requesting the OAuth token.<br>
             This may be caused by the requested service, the OAuth provider or Syncany.</p>
         <p class tagline>Please consult Syncany logfiles or create an issue on <a href="https://github.com/syncany/syncany/issues">Syncany's issue tracker</a> if the problem persists.
         </p>

--- a/syncany-lib/src/main/resources/org/syncany/plugins/oauth/ValidWebResponse.html
+++ b/syncany-lib/src/main/resources/org/syncany/plugins/oauth/ValidWebResponse.html
@@ -26,7 +26,7 @@
         <h2>Syncany</h2>
 
         <p class="tagline">
-            The OAuth token was successfully received by Syncany.<br />
+            The OAuth token was successfully received by Syncany.<br>
             Please head back to the Syncany repository wizard to proceed.
         </p>
     </div>

--- a/syncany-lib/src/test/java/org/syncany/plugins/dummy/DummyTransferManager.java
+++ b/syncany-lib/src/test/java/org/syncany/plugins/dummy/DummyTransferManager.java
@@ -26,7 +26,7 @@ import org.syncany.plugins.transfer.StorageException;
 import org.syncany.plugins.transfer.files.RemoteFile;
 
 /**
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Christian Roth (christian.roth@port17.de)
  */
 
 public class DummyTransferManager extends AbstractTransferManager {

--- a/syncany-lib/src/test/java/org/syncany/plugins/dummy/DummyTransferPlugin.java
+++ b/syncany-lib/src/test/java/org/syncany/plugins/dummy/DummyTransferPlugin.java
@@ -20,7 +20,7 @@ package org.syncany.plugins.dummy;
 import org.syncany.plugins.transfer.TransferPlugin;
 
 /**
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Christian Roth (christian.roth@port17.de)
  */
 public class DummyTransferPlugin extends TransferPlugin {
 	public DummyTransferPlugin() {

--- a/syncany-lib/src/test/java/org/syncany/plugins/dummy/DummyTransferSettings.java
+++ b/syncany-lib/src/test/java/org/syncany/plugins/dummy/DummyTransferSettings.java
@@ -26,7 +26,7 @@ import org.syncany.plugins.transfer.StorageException;
 import org.syncany.plugins.transfer.TransferSettings;
 
 /**
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Christian Roth (christian.roth@port17.de)
  */
 public class DummyTransferSettings extends TransferSettings {
 	public enum DummyEnum {

--- a/syncany-lib/src/test/java/org/syncany/plugins/unreliable_local/UnreliableLocalTransferPlugin.java
+++ b/syncany-lib/src/test/java/org/syncany/plugins/unreliable_local/UnreliableLocalTransferPlugin.java
@@ -25,7 +25,7 @@ import org.syncany.plugins.transfer.TransferPlugin;
  * plugin (e.g upload, download, ...) can be failed on purpose through
  * regular expressions on the operation signature.
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class UnreliableLocalTransferPlugin extends TransferPlugin {
 	public UnreliableLocalTransferPlugin() {

--- a/syncany-lib/src/test/java/org/syncany/tests/util/TestClient.java
+++ b/syncany-lib/src/test/java/org/syncany/tests/util/TestClient.java
@@ -255,7 +255,7 @@ public class TestClient extends Client {
 			}
 		}
 		catch (Exception e) {
-			throw new Exception("Move failed: " + fileFrom + " --&gt; " + fileTo, e);
+			throw new Exception("Move failed: " + fileFrom + " --> " + fileTo, e);
 		}
 	}
 

--- a/syncany-lib/src/test/java/org/syncany/tests/util/TestClient.java
+++ b/syncany-lib/src/test/java/org/syncany/tests/util/TestClient.java
@@ -255,7 +255,7 @@ public class TestClient extends Client {
 			}
 		}
 		catch (Exception e) {
-			throw new Exception("Move failed: " + fileFrom + " --> " + fileTo, e);
+			throw new Exception("Move failed: " + fileFrom + " --&gt; " + fileTo, e);
 		}
 	}
 

--- a/syncany-lib/src/test/java/org/syncany/tests/util/TestConfigUtil.java
+++ b/syncany-lib/src/test/java/org/syncany/tests/util/TestConfigUtil.java
@@ -295,7 +295,7 @@ public class TestConfigUtil {
 			TestFileUtil.deleteDirectory(config.getAppDir());
 		}
 
-		// TODO [low] workaround: delete empty parent folder of getAppDir() --&gt; ROOT/app/.. --&gt; ROOT/
+		// TODO [low] workaround: delete empty parent folder of getAppDir() --> ROOT/app/.. --> ROOT/
 		config.getLocalDir().getParentFile().delete(); // if empty!
 
 		deleteTestLocalConnection(config);

--- a/syncany-lib/src/test/java/org/syncany/tests/util/TestConfigUtil.java
+++ b/syncany-lib/src/test/java/org/syncany/tests/util/TestConfigUtil.java
@@ -295,7 +295,7 @@ public class TestConfigUtil {
 			TestFileUtil.deleteDirectory(config.getAppDir());
 		}
 
-		// TODO [low] workaround: delete empty parent folder of getAppDir() --> ROOT/app/.. --> ROOT/
+		// TODO [low] workaround: delete empty parent folder of getAppDir() --&gt; ROOT/app/.. --&gt; ROOT/
 		config.getLocalDir().getParentFile().delete(); // if empty!
 
 		deleteTestLocalConnection(config);

--- a/syncany-util/src/main/java/org/syncany/util/Base58.java
+++ b/syncany-util/src/main/java/org/syncany/util/Base58.java
@@ -23,7 +23,7 @@ import java.security.NoSuchAlgorithmException;
  * <p>Base58 is a way to encode Bitcoin addresses as numbers and letters. Note that this is not the same base58 as used by
  * Flickr, which you may see reference to around the internet.</p>
  *
- * <p>Satoshi says: why base-58 instead of standard base-64 encoding?<p>
+ * <p>Satoshi says: why base-58 instead of standard base-64 encoding?</p>
  *
  * <ul>
  *   <li>Don't want 0OIl characters that look the same in some fonts and

--- a/syncany-util/src/main/java/org/syncany/util/CollectionUtil.java
+++ b/syncany-util/src/main/java/org/syncany/util/CollectionUtil.java
@@ -22,13 +22,13 @@ import java.util.Collection;
 
 public abstract class CollectionUtil {	
 	/**
-	 * Checks if the collection contains only the given allowed items. <tt>list</tt> 
+	 * Checks if the collection contains only the given allowed items. <code>list</code>
 	 * may contain zero to max(allowedItems) items from allowedItems.
 	 * 
 	 * <p><b>Examples:</b><br>
-	 * <tt>containsOnly(Arrays.asList(new Integer[] { 1, 2, 3 }))        --> true</tt><br>
-	 * <tt>containsOnly(Arrays.asList(new Integer[] { 1, 2, 3 }), 1, 2)  --> false, 3 missing</tt><br>
-	 * <tt>containsOnly(Arrays.asList(new Integer[] { 1, 2, 3 }), 1, 99) --> false, 3 missing</tt>
+	 * <code>containsOnly(Arrays.asList(new Integer[] { 1, 2, 3 }))        --&gt; true</code><br>
+	 * <code>containsOnly(Arrays.asList(new Integer[] { 1, 2, 3 }), 1, 2)  --&gt; false, 3 missing</code><br>
+	 * <code>containsOnly(Arrays.asList(new Integer[] { 1, 2, 3 }), 1, 99) --&gt; false, 3 missing</code>
 	 */
 	@SafeVarargs
 	public static <T> boolean containsOnly(Collection<T> list, T... allowedItems) {
@@ -36,13 +36,13 @@ public abstract class CollectionUtil {
 	}
 	
 	/**
-	 * Checks if the collection contains only the given allowed items. <tt>list</tt> 
+	 * Checks if the collection contains only the given allowed items. <code>list</code>
 	 * may contain zero to max(allowedItems) items from allowedItems.
 	 * 
 	 * <p><b>Examples:</b><br>
-	 * <tt>containsOnly(Arrays.asList(new Integer[] { 1, 2, 3 }), Arrays.asList(new Integer[] { }))       --> true</tt><br>
-	 * <tt>containsOnly(Arrays.asList(new Integer[] { 1, 2, 3 }), Arrays.asList(new Integer[] { 1, 2 }))  --> false, 3 missing</tt><br>
-	 * <tt>containsOnly(Arrays.asList(new Integer[] { 1, 2, 3 }), Arrays.asList(new Integer[] { 1, 99 })) --> false, 3 missing</tt>
+	 * <code>containsOnly(Arrays.asList(new Integer[] { 1, 2, 3 }), Arrays.asList(new Integer[] { }))       --&gt; true</code><br>
+	 * <code>containsOnly(Arrays.asList(new Integer[] { 1, 2, 3 }), Arrays.asList(new Integer[] { 1, 2 }))  --&gt; false, 3 missing</code><br>
+	 * <code>containsOnly(Arrays.asList(new Integer[] { 1, 2, 3 }), Arrays.asList(new Integer[] { 1, 99 })) --&gt; false, 3 missing</code>
 	 */
 	public static <T> boolean containsOnly(Collection<T> list, Collection<T> allowedItems) {
 		for (T item : list) {
@@ -55,12 +55,12 @@ public abstract class CollectionUtil {
 	}	
 
 	/**
-	 * Checks if the collection contains exactly the given <tt>mustHaveItems</tt>. 
+	 * Checks if the collection contains exactly the given <code>mustHaveItems</code>.
 	 * 
 	 * <p><b>Examples:</b><br>
-	 * <tt>containsOnly(Arrays.asList(new Integer[] { 1, 2, 3 }))          --> false</tt><br>
-	 * <tt>containsOnly(Arrays.asList(new Integer[] { 1, 2, 3 }), 1, 99)   --> false</tt><br>
-	 * <tt>containsOnly(Arrays.asList(new Integer[] { 1, 2, 3 }), 1, 2, 3) --> true</tt>
+	 * <code>containsOnly(Arrays.asList(new Integer[] { 1, 2, 3 }))          --&gt; false</code><br>
+	 * <code>containsOnly(Arrays.asList(new Integer[] { 1, 2, 3 }), 1, 99)   --&gt; false</code><br>
+	 * <code>containsOnly(Arrays.asList(new Integer[] { 1, 2, 3 }), 1, 2, 3) --&gt; true</code>
 	 */
 	@SafeVarargs
 	public static <T> boolean containsExactly(Collection<T> list, T... mustHaveItems) {
@@ -68,12 +68,12 @@ public abstract class CollectionUtil {
 	}
 	
 	/**
-	 * Checks if the collection contains exactly the given <tt>mustHaveItems</tt>.
+	 * Checks if the collection contains exactly the given <code>mustHaveItems</code>.
 	 * 
 	 * <p><b>Examples:</b><br>
-	 * <tt>containsOnly(Arrays.asList(new Integer[] { 1, 2, 3 }), Arrays.asList(new Integer[] { }))         --> false</tt><br>
-	 * <tt>containsOnly(Arrays.asList(new Integer[] { 1, 2, 3 }), Arrays.asList(new Integer[] { 1, 99 }))   --> false</tt><br>
-	 * <tt>containsOnly(Arrays.asList(new Integer[] { 1, 2, 3 }), Arrays.asList(new Integer[] { 1, 2, 3 })) --> true</tt>
+	 * <code>containsOnly(Arrays.asList(new Integer[] { 1, 2, 3 }), Arrays.asList(new Integer[] { }))         --&gt; false</code><br>
+	 * <code>containsOnly(Arrays.asList(new Integer[] { 1, 2, 3 }), Arrays.asList(new Integer[] { 1, 99 }))   --&gt; false</code><br>
+	 * <code>containsOnly(Arrays.asList(new Integer[] { 1, 2, 3 }), Arrays.asList(new Integer[] { 1, 2, 3 })) --&gt; true</code>
 	 */
 	public static <T> boolean containsExactly(Collection<T> list, Collection<T> mustHaveItems) {
 		return list.containsAll(mustHaveItems) && mustHaveItems.containsAll(list);

--- a/syncany-util/src/main/java/org/syncany/util/FileUtil.java
+++ b/syncany-util/src/main/java/org/syncany/util/FileUtil.java
@@ -35,7 +35,7 @@ import java.text.DecimalFormat;
 /**
  * A file utility class
  *
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class FileUtil {
 	public static String getRelativePath(File base, File file) {
@@ -186,15 +186,15 @@ public class FileUtil {
 	}
 
 	/**
-	 * Replaces the <tt>exists()</tt> method in the <tt>File</tt> class by taking symlinks into account.
-	 * The method returns <tt>true</tt> if the file exists, <tt>false</tt> otherwise.
+	 * Replaces the <code>exists()</code> method in the <code>File</code> class by taking symlinks into account.
+	 * The method returns <code>true</code> if the file exists, <code>false</code> otherwise.
 	 *
-	 * <p>Note: The method returns <tt>true</tt>, if a symlink exists, but points to a
+	 * <p>Note: The method returns <code>true</code>, if a symlink exists, but points to a
 	 * non-existing target. This behavior is different from the classic
-	 * {@link #exists(File) exists()}-method in the <tt>File</tt> class.
+	 * {@link #exists(File) exists()}-method in the <code>File</code> class.
 	 *
 	 * @param file A file
-	 * @return Returns <tt>true</tt> if a file exists (even if its symlink target does not), <tt>false</tt> otherwise
+	 * @return Returns <code>true</code> if a file exists (even if its symlink target does not), <code>false</code> otherwise
 	 */
 	public static boolean exists(File file) {
 		try {

--- a/syncany-util/src/main/java/org/syncany/util/LimitedDosFileAttributes.java
+++ b/syncany-util/src/main/java/org/syncany/util/LimitedDosFileAttributes.java
@@ -21,7 +21,7 @@ import java.nio.file.attribute.DosFileAttributes;
 import java.nio.file.attribute.FileTime;
 
 /**
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class LimitedDosFileAttributes implements DosFileAttributes {
 	private String dosAttributes;

--- a/syncany-util/src/main/java/org/syncany/util/PidFileUtil.java
+++ b/syncany-util/src/main/java/org/syncany/util/PidFileUtil.java
@@ -36,7 +36,7 @@ import java.util.logging.Logger;
  * Java process, and to check whether the process indicated by a PID file is 
  * still running.   
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
 */
 public class PidFileUtil {
 	private static final Logger logger = Logger.getLogger(PidFileUtil.class.getSimpleName());
@@ -90,7 +90,7 @@ public class PidFileUtil {
 	/**
 	 * Determines whether a process is running, based on the given PID file. The method
 	 * reads the PID file and then calls {@link #isProcessRunning(int)}. If the PID file
-	 * does not exist, it returns <tt>false</tt>. 
+	 * does not exist, it returns <code>false</code>.
 	 */
 	public static boolean isProcessRunning(File pidFile) {
 		if (pidFile.exists()) {
@@ -126,7 +126,7 @@ public class PidFileUtil {
 	
 	/**
 	 * Uses the {@link RuntimeMXBean}'s name to determine the PID. On Linux, this name 
-	 * typically has a value like <tt>12345@localhost</tt> where 12345 is the PID.
+	 * typically has a value like <code>12345@localhost</code> where 12345 is the PID.
 	 * However, this is not guaranteed for every VM, so this is only one of two implementations.
 	 *  
 	 * @see http://stackoverflow.com/a/35885/1440785
@@ -146,7 +146,7 @@ public class PidFileUtil {
 	}
 
 	/**
-	 * Uses the private method <tt>VMManagement.getProcessId()</tt> of Sun's <tt>sun.management.VMManagement</tt>
+	 * Uses the private method <code>VMManagement.getProcessId()</code> of Sun's <code>sun.management.VMManagement</code>
 	 * class to determine the PID (using reflection to make the relevant fields visible).
 	 * 
 	 * @see http://stackoverflow.com/a/12066696/1440785
@@ -172,7 +172,7 @@ public class PidFileUtil {
 	
 	/**
 	 * Determines whether a process with the given PID is running using the POSIX 
-	 * <tt>ps -p $pid</tt> command.
+	 * <code>ps -p $pid</code> command.
 	 * 
 	 * @param pid Process ID (PID) to check
 	 * @return True if process is running, false otherwise
@@ -196,7 +196,7 @@ public class PidFileUtil {
 
 	/**
 	 * Determines whether a process with the given PID is running using the Windows 
-	 * <tt>tasklist</tt> command.
+	 * <code>tasklist</code> command.
 	 * 
 	 * @see http://stackoverflow.com/questions/2533984/java-checking-if-any-process-id-is-currently-running-on-windows
 	 */

--- a/syncany-util/src/main/java/org/syncany/util/ReflectionUtil.java
+++ b/syncany-util/src/main/java/org/syncany/util/ReflectionUtil.java
@@ -29,7 +29,7 @@ import java.util.List;
  * Utility class to find classes, methods and fields with certain properties -
  * typically having an annotation or a certain erasure.
  *
- * @author Christian Roth <christian.roth@port17.de>
+ * @author Christian Roth (christian.roth@port17.de)
  */
 public abstract class ReflectionUtil {
 	public static Field[] getAllFieldsWithAnnotation(Class<?> clazz, Class<? extends Annotation> annotation) {

--- a/syncany-util/src/main/java/org/syncany/util/StringUtil.java
+++ b/syncany-util/src/main/java/org/syncany/util/StringUtil.java
@@ -28,7 +28,7 @@ import javax.xml.bind.DatatypeConverter;
 /**
  * Utility class for common application string functions.
  * 
- * @author Philipp C. Heckel <philipp.heckel@gmail.com>
+ * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
 public class StringUtil {   
 	/**
@@ -37,11 +37,11 @@ public class StringUtil {
 	 * 
 	 * <p>Examples:
 	 * <ul>
-	 *  <li><tt>toCamelCase("hello world") -&gt; "HelloWorld"</tt></li>
-	 *  <li><tt>toCamelCase("hello_world") -&gt; "HelloWorld"</tt></li>
-	 *  <li><tt>toCamelCase("hello_World") -&gt; "HelloWorld"</tt></li>
-	 *  <li><tt>toCamelCase("helloWorld") -&gt; "HelloWorld"</tt></li>
-	 *  <li><tt>toCamelCase("HelloWorld") -&gt; "HelloWorld"</tt></li>
+	 *  <li><code>toCamelCase("hello world") -&gt; "HelloWorld"</code></li>
+	 *  <li><code>toCamelCase("hello_world") -&gt; "HelloWorld"</code></li>
+	 *  <li><code>toCamelCase("hello_World") -&gt; "HelloWorld"</code></li>
+	 *  <li><code>toCamelCase("helloWorld") -&gt; "HelloWorld"</code></li>
+	 *  <li><code>toCamelCase("HelloWorld") -&gt; "HelloWorld"</code></li>
 	 * </ul>
 	 */
     public static String toCamelCase(String str) {
@@ -65,8 +65,8 @@ public class StringUtil {
      * 
 	 * <p>Examples:
 	 * <ul>
-	 *  <li><tt>toUnderScoreDelimited("HelloWorld") -&gt; "hello_world"</tt></li>
-	 *  <li><tt>toUnderScoreDelimited("helloWorld") -&gt; "hello_world"</tt></li>
+	 *  <li><code>toUnderScoreDelimited("HelloWorld") -&gt; "hello_world"</code></li>
+	 *  <li><code>toUnderScoreDelimited("helloWorld") -&gt; "hello_world"</code></li>
 	 * </ul>
      */
     public static String toSnakeCase(String str) {
@@ -95,7 +95,7 @@ public class StringUtil {
     
     /**
      * Converts a byte array to a lower case hex representation.
-     * If the given byte array is <tt>null</tt>, an empty string is returned.
+     * If the given byte array is <code>null</code>, an empty string is returned.
      */
     public static String toHex(byte[] bytes) {
     	if (bytes == null) {

--- a/syncany-util/src/test/java/org/syncany/tests/util/TestFileUtil.java
+++ b/syncany-util/src/test/java/org/syncany/tests/util/TestFileUtil.java
@@ -43,7 +43,7 @@ import org.syncany.util.FileUtil;
 /**
  * This class provides file I/O helper methods for writing tests
  *
- * @author Philipp Heckel <philipp.heckel@gmail.com>
+ * @author Philipp Heckel (philipp.heckel@gmail.com)
  * @author Nikolai Hellwig
  * @author Andreas Fenske
  */
@@ -333,11 +333,11 @@ public class TestFileUtil {
 
 	/**
 	 * Replaces the {@link File#canRead() canRead()} method in the {@link File} class by taking
-	 * symlinks into account. Returns <tt>true</tt> if a symlink exists even if its target file
+	 * symlinks into account. Returns <code>true</code> if a symlink exists even if its target file
 	 * does not exist and can hence not be read.
 	 *
 	 * @param file A file
-	 * @return Returns <tt>true</tt> if the file can be read (or the symlink exists), <tt>false</tt> otherwise
+	 * @return Returns <code>true</code> if the file can be read (or the symlink exists), <code>false</code> otherwise
 	 */
 	public static boolean canRead(File file) {
 		if (FileUtil.isSymlink(file)) {


### PR DESCRIPTION
The APIviz doclet is currently unmaintained. Notably, it is not compatible with Java 11, so therefore we must stop using it if we are to upgrade to Java 11.

This PR updates the all the javadoc comments to be compatible with the standard doclet (bundled with the JVM).

If we want to adopt a new doclet in the future (with a nicer syntax) that's fine, but I am not familiar with other doclets that are maintained and compatible with Java 11. Further, whatever doclet we adopt, it would be another thing for contributors to learn, so we have to make sure it's not too complicated. The standard doclet seems good enough for now.