### PR TITLE
remove heavy jaxb dependency

### DIFF
--- a/syncany-cli/build.gradle
+++ b/syncany-cli/build.gradle
@@ -17,12 +17,6 @@ dependencies {
 	implementation			"org.apache.httpcomponents:httpclient:4.3.4"
 	implementation			"org.simpleframework:simple-xml:2.7.1"
 
-	// Because Java 9+ does not automatically include a JAXB provider
-	// https://stackoverflow.com/questions/43574426/how-to-resolve-java-lang-noclassdeffounderror-javax-xml-bind-jaxbexception-in-j#43574427
-	// https://blog.sourced-bvba.be/article/2017/12/17/java9-spring/
-	implementation			"javax.xml.bind:jaxb-api:2.3.1"
-	implementation			"org.glassfish.jaxb:jaxb-runtime:2.3.1"
-
 	testImplementation		"com.github.stefanbirkner:system-rules:1.5.0"
 
 	testImplementation		project(path: ":syncany-lib", configuration: "tests")

--- a/syncany-util/build.gradle
+++ b/syncany-util/build.gradle
@@ -19,12 +19,6 @@ dependencies {
 	implementation			"commons-io:commons-io:2.4"
 	implementation			"org.hsqldb:hsqldb:2.3.1"
 
-	// Because Java 9+ does not automatically include a JAXB provider
-	// https://stackoverflow.com/questions/43574426/how-to-resolve-java-lang-noclassdeffounderror-javax-xml-bind-jaxbexception-in-j#43574427
-	// https://blog.sourced-bvba.be/article/2017/12/17/java9-spring/
-	implementation			"javax.xml.bind:jaxb-api:2.3.1"
-	implementation			"org.glassfish.jaxb:jaxb-runtime:2.3.1"
-
 	testImplementation		"junit:junit:4.9"
 	testImplementation		"org.junit.jupiter:junit-jupiter:5.4.2"
 	testImplementation		"org.junit.vintage:junit-vintage-engine:5.4.2"

--- a/syncany-util/src/main/java/org/syncany/util/StringUtil.java
+++ b/syncany-util/src/main/java/org/syncany/util/StringUtil.java
@@ -115,6 +115,10 @@ public class StringUtil {
      * Creates byte array from a hex represented string.
      */
     public static byte[] fromHex(String hexString) {
+    	if (hexString.length() % 2 == 1) {
+    		throw new IllegalArgumentException("hex string must be of even length");
+		}
+
     	char[] hex = hexString.toCharArray();
 		byte[] raw = new byte[hex.length / 2];
 		for (int src = 0, dst = 0; dst < raw.length; ++dst) {

--- a/syncany-util/src/main/java/org/syncany/util/StringUtil.java
+++ b/syncany-util/src/main/java/org/syncany/util/StringUtil.java
@@ -1,6 +1,6 @@
 /*
  * Syncany, www.syncany.org
- * Copyright (C) 2011-2016 Philipp C. Heckel <philipp.heckel@gmail.com> 
+ * Copyright (C) 2011-2016 Philipp C. Heckel <philipp.heckel@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -25,14 +25,14 @@ import java.util.List;
 
 /**
  * Utility class for common application string functions.
- * 
+ *
  * @author Philipp C. Heckel (philipp.heckel@gmail.com)
  */
-public class StringUtil {   
+public class StringUtil {
 	/**
 	 * Transforms a string to a camel case representation, including the
 	 * first character.
-	 * 
+	 *
 	 * <p>Examples:
 	 * <ul>
 	 *  <li><code>toCamelCase("hello world") -&gt; "HelloWorld"</code></li>
@@ -42,64 +42,61 @@ public class StringUtil {
 	 *  <li><code>toCamelCase("HelloWorld") -&gt; "HelloWorld"</code></li>
 	 * </ul>
 	 */
-    public static String toCamelCase(String str) {
-        StringBuilder sb = new StringBuilder();
+	public static String toCamelCase(String str) {
+		StringBuilder sb = new StringBuilder();
 
-        for (String s : str.split("[-_ ]")) {
-        	if (s.length() > 0) {
-	            sb.append(Character.toUpperCase(s.charAt(0)));
-	
-	            if (s.length() > 1) {
-	                sb.append(s.substring(1, s.length()));
-	            }
-        	}
-        }
+		for (String s : str.split("[-_ ]")) {
+			if (s.length() > 0) {
+				sb.append(Character.toUpperCase(s.charAt(0)));
 
-        return sb.toString();
-    }
-    
-    /**
-     * Transforms a string to underscore-delimited representation.
-     * 
+				if (s.length() > 1) {
+					sb.append(s.substring(1, s.length()));
+				}
+			}
+		}
+
+		return sb.toString();
+	}
+
+	/**
+	 * Transforms a string to underscore-delimited representation.
+	 *
 	 * <p>Examples:
 	 * <ul>
 	 *  <li><code>toUnderScoreDelimited("HelloWorld") -&gt; "hello_world"</code></li>
 	 *  <li><code>toUnderScoreDelimited("helloWorld") -&gt; "hello_world"</code></li>
 	 * </ul>
-     */
-    public static String toSnakeCase(String str) {
+	 */
+	public static String toSnakeCase(String str) {
 		StringBuilder sb = new StringBuilder();
 
-        for (char c : str.toCharArray()) {   
-        	if (Character.isLetter(c) || Character.isDigit(c)) {
-        		if (Character.isUpperCase(c)) {
-            		if (sb.length() > 0) {
-            			sb.append("_");
-            		}
-            		
-            		sb.append(Character.toLowerCase(c));
-            	}
-            	else {
-            		sb.append(c);
-            	}
-        	}
-        	else {
-        		sb.append("_");
-        	}
-        }
+		for (char c : str.toCharArray()) {
+			if (Character.isLetter(c) || Character.isDigit(c)) {
+				if (Character.isUpperCase(c)) {
+					if (sb.length() > 0) {
+						sb.append("_");
+					}
 
-        return sb.toString();
+					sb.append(Character.toLowerCase(c));
+				} else {
+					sb.append(c);
+				}
+			} else {
+				sb.append("_");
+			}
+		}
+
+		return sb.toString();
 	}
-    
-    /**
-     * Converts a byte array to a lower case hex representation.
-     * If the given byte array is <code>null</code>, an empty string is returned.
-     */
-    public static String toHex(byte[] bytes) {
-    	if (bytes == null) {
-    		return "";
-    	}
-    	else {
+
+	/**
+	 * Converts a byte array to a lower case hex representation.
+	 * If the given byte array is <code>null</code>, an empty string is returned.
+	 */
+	public static String toHex(byte[] bytes) {
+		if (bytes == null) {
+			return "";
+		} else {
 			final char[] hexArray = "0123456789ABCDEF".toCharArray();
 			char[] hexChars = new char[bytes.length * 2];
 			for (int j = 0; j < bytes.length; j++) {
@@ -108,18 +105,18 @@ public class StringUtil {
 				hexChars[j * 2 + 1] = hexArray[v & 0x0F];
 			}
 			return String.valueOf(hexChars).toLowerCase();
-    	}
-    }
-    
-    /**
-     * Creates byte array from a hex represented string.
-     */
-    public static byte[] fromHex(String hexString) {
-    	if (hexString.length() % 2 == 1) {
-    		throw new IllegalArgumentException("hex string must be of even length");
+		}
+	}
+
+	/**
+	 * Creates byte array from a hex represented string.
+	 */
+	public static byte[] fromHex(String hexString) {
+		if (hexString.length() % 2 == 1) {
+			throw new IllegalArgumentException("hex string must be of even length");
 		}
 
-    	char[] hex = hexString.toCharArray();
+		char[] hex = hexString.toCharArray();
 		byte[] raw = new byte[hex.length / 2];
 		for (int src = 0, dst = 0; dst < raw.length; ++dst) {
 			int hi = Character.digit(hex[src++], 16);
@@ -129,81 +126,79 @@ public class StringUtil {
 			raw[dst] = (byte) (hi << 4 | lo);
 		}
 		return raw;
-    }
-    
-    /**
-     * Creates a byte array from a given string, using the UTF-8
-     * encoding. This calls {@link String#getBytes(java.nio.charset.Charset)} 
-     * internally with "UTF-8" as charset.
-     */
-    public static byte[] toBytesUTF8(String s) {
-    	try {
+	}
+
+	/**
+	 * Creates a byte array from a given string, using the UTF-8
+	 * encoding. This calls {@link String#getBytes(java.nio.charset.Charset)}
+	 * internally with "UTF-8" as charset.
+	 */
+	public static byte[] toBytesUTF8(String s) {
+		try {
 			return s.getBytes("UTF-8");
-		} 
-    	catch (UnsupportedEncodingException e) {
+		} catch (UnsupportedEncodingException e) {
 			throw new RuntimeException("JVM does not support UTF-8 encoding.", e);
 		}
-    }
-    
-    /**
-     * Returns the count of the substring 
-     */
-    public static int substrCount(String haystack, String needle) {
-    	int lastIndex = 0;
-    	int count = 0;
+	}
 
-    	if (needle != null && haystack != null) {
+	/**
+	 * Returns the count of the substring
+	 */
+	public static int substrCount(String haystack, String needle) {
+		int lastIndex = 0;
+		int count = 0;
+
+		if (needle != null && haystack != null) {
 			while (lastIndex != -1) {
 				lastIndex = haystack.indexOf(needle, lastIndex);
-	
+
 				if (lastIndex != -1) {
 					count++;
 					lastIndex += needle.length();
 				}
-	    	}
-    	}
-    	
+			}
+		}
+
 		return count;
-    }
-    
-    public static String getStackTrace(Exception exception) {
-    	StringWriter stackTraceStringWriter = new StringWriter();
-    	exception.printStackTrace(new PrintWriter(stackTraceStringWriter));
-    	
-    	return stackTraceStringWriter.toString();
-    }
-	
+	}
+
+	public static String getStackTrace(Exception exception) {
+		StringWriter stackTraceStringWriter = new StringWriter();
+		exception.printStackTrace(new PrintWriter(stackTraceStringWriter));
+
+		return stackTraceStringWriter.toString();
+	}
+
 	public static <T> String join(List<T> objects, String delimiter, StringJoinListener<T> listener) {
 		StringBuilder objectsStr = new StringBuilder();
-		
-		for (int i=0; i<objects.size(); i++) {
+
+		for (int i = 0; i < objects.size(); i++) {
 			if (listener != null) {
 				objectsStr.append(listener.getString(objects.get(i)));
-			}
-			else {
+			} else {
 				objectsStr.append(objects.get(i).toString());
 			}
-			
-			if (i < objects.size()-1) { 
+
+			if (i < objects.size() - 1) {
 				objectsStr.append(delimiter);
-			}			
+			}
 		}
-		
+
 		return objectsStr.toString();
-	}   
-	
+	}
+
 	public static <T> String join(List<T> objects, String delimiter) {
 		return join(objects, delimiter, null);
-	} 
-	
+	}
+
 	public static <T> String join(T[] objects, String delimiter, StringJoinListener<T> listener) {
 		return join(Arrays.asList(objects), delimiter, listener);
-	}   
-	
+	}
+
 	public static <T> String join(T[] objects, String delimiter) {
 		return join(Arrays.asList(objects), delimiter, null);
-	}   
-	
+	}
+
 	public static interface StringJoinListener<T> {
 		public String getString(T object);
 	}

--- a/syncany-util/src/main/java/org/syncany/util/StringUtil.java
+++ b/syncany-util/src/main/java/org/syncany/util/StringUtil.java
@@ -23,8 +23,6 @@ import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.xml.bind.DatatypeConverter;
-
 /**
  * Utility class for common application string functions.
  * 
@@ -102,15 +100,31 @@ public class StringUtil {
     		return "";
     	}
     	else {
-    		return DatatypeConverter.printHexBinary(bytes).toLowerCase();
+			final char[] hexArray = "0123456789ABCDEF".toCharArray();
+			char[] hexChars = new char[bytes.length * 2];
+			for (int j = 0; j < bytes.length; j++) {
+				int v = bytes[j] & 0xFF;
+				hexChars[j * 2] = hexArray[v >>> 4];
+				hexChars[j * 2 + 1] = hexArray[v & 0x0F];
+			}
+			return String.valueOf(hexChars).toLowerCase();
     	}
     }
     
     /**
      * Creates byte array from a hex represented string.
      */
-    public static byte[] fromHex(String s) {
-    	return DatatypeConverter.parseHexBinary(s); // fast!    	
+    public static byte[] fromHex(String hexString) {
+    	char[] hex = hexString.toCharArray();
+		byte[] raw = new byte[hex.length / 2];
+		for (int src = 0, dst = 0; dst < raw.length; ++dst) {
+			int hi = Character.digit(hex[src++], 16);
+			int lo = Character.digit(hex[src++], 16);
+			if ((hi < 0) || (lo < 0))
+				throw new IllegalArgumentException();
+			raw[dst] = (byte) (hi << 4 | lo);
+		}
+		return raw;
     }
     
     /**

--- a/syncany-util/src/test/java/org/syncany/tests/util/StringUtilTest.java
+++ b/syncany-util/src/test/java/org/syncany/tests/util/StringUtilTest.java
@@ -32,6 +32,7 @@ public class StringUtilTest {
 		assertEquals("abcdeffaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", StringUtil.toHex(StringUtil.fromHex("abcdeffaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")));
 		assertEquals("", StringUtil.toHex(StringUtil.fromHex("")));		
 		assertEquals("00abcdefaaaa", StringUtil.toHex(StringUtil.fromHex("00abcdefaaaa")));
+		assertEquals("000000", StringUtil.toHex(StringUtil.fromHex("000000")));
 	}
 	
 	@Test(expected=Exception.class)

--- a/syncany-util/src/test/java/org/syncany/tests/util/StringUtilTest.java
+++ b/syncany-util/src/test/java/org/syncany/tests/util/StringUtilTest.java
@@ -17,6 +17,8 @@
  */
 package org.syncany.tests.util;
 
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.Arrays;
 
 import org.junit.Test;
@@ -61,7 +63,10 @@ public class StringUtilTest {
 		assertEquals("1.9 + 2.8 + 3.7", StringUtil.join(new Double[] { 1.911, 2.833, 3.744 }, " + ", new StringJoinListener<Double>() {
 			@Override
 			public String getString(Double number) {
-				return String.format("%.1f", number);
+				// separator has to be set explicitly otherwise it will fail on systems which are using others than '.' (e.g. German layout)
+				DecimalFormatSymbols decimalSymbols = DecimalFormatSymbols.getInstance();
+				decimalSymbols.setDecimalSeparator('.');
+				return new DecimalFormat("0.0", decimalSymbols).format(number);
 			}			
 		}));
 	}

--- a/syncany-util/src/test/java/org/syncany/tests/util/StringUtilTest.java
+++ b/syncany-util/src/test/java/org/syncany/tests/util/StringUtilTest.java
@@ -31,6 +31,7 @@ public class StringUtilTest {
 	public void testFromHexToHex() {
 		assertEquals("abcdeffaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", StringUtil.toHex(StringUtil.fromHex("abcdeffaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")));
 		assertEquals("", StringUtil.toHex(StringUtil.fromHex("")));		
+		assertEquals("00abcdefaaaa", StringUtil.toHex(StringUtil.fromHex("00abcdefaaaa")));
 	}
 	
 	@Test(expected=Exception.class)
@@ -47,7 +48,7 @@ public class StringUtilTest {
 	public void testFromHexInvalid3() {
 		StringUtil.toHex(StringUtil.fromHex("INVALID"));
 	}
-	
+
 	@Test
 	public void testStringJoin() {
 		assertEquals("a;b;c", StringUtil.join(new String[] { "a",  "b", "c" }, ";"));

--- a/syncany-util/src/test/java/org/syncany/tests/util/StringUtilTest.java
+++ b/syncany-util/src/test/java/org/syncany/tests/util/StringUtilTest.java
@@ -17,14 +17,13 @@
  */
 package org.syncany.tests.util;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-
 import java.util.Arrays;
 
 import org.junit.Test;
 import org.syncany.util.StringUtil;
 import org.syncany.util.StringUtil.StringJoinListener;
+
+import static org.junit.Assert.*;
 
 public class StringUtilTest {
 	@Test 
@@ -35,9 +34,14 @@ public class StringUtilTest {
 		assertEquals("000000", StringUtil.toHex(StringUtil.fromHex("000000")));
 	}
 	
-	@Test(expected=Exception.class)
-	public void testFromHexInvalid1() {
+	@Test(expected=IllegalArgumentException.class)
+	public void testFromHexIllegal1() {
 		StringUtil.toHex(StringUtil.fromHex("a"));
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void testFromHexIllegal2() {
+		StringUtil.toHex(StringUtil.fromHex("0000000"));
 	}
 	
 	@Test(expected=Exception.class)

--- a/syncany-util/src/test/java/org/syncany/tests/util/StringUtilTest.java
+++ b/syncany-util/src/test/java/org/syncany/tests/util/StringUtilTest.java
@@ -47,12 +47,12 @@ public class StringUtilTest {
 	}
 	
 	@Test(expected=Exception.class)
-	public void testFromHexInvalid2() {
+	public void testFromHexInvalid1() {
 		StringUtil.toHex(StringUtil.fromHex("INVALID!"));
 	}
 	
 	@Test(expected=Exception.class)
-	public void testFromHexInvalid3() {
+	public void testFromHexInvalid2() {
 		StringUtil.toHex(StringUtil.fromHex("INVALID"));
 	}
 


### PR DESCRIPTION
Remove dependency to jaxb since it was (as far as I see) only used to convert hex strings. Using an additonal library only for such a basic function is way too heavy.

fixes #635  - tried on windows 10

The intention of this pr is to leave syncany in a state where others can easily try it out and maybe find it fun to continue ;-)